### PR TITLE
class UnauthInterface

### DIFF
--- a/pyxnat/__init__.py
+++ b/pyxnat/__init__.py
@@ -1,6 +1,6 @@
 __version__ = '0.9.0'
 
-from .core import Interface
+from .core import Interface, UnauthInterface
 from .core import SearchManager
 from .core import CacheManager
 from .core import Select

--- a/pyxnat/core/__init__.py
+++ b/pyxnat/core/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from .interfaces import Interface
+from .interfaces import Interface, UnauthInterface
 from .search import SearchManager
 from .cache import CacheManager
 from .select import Select


### PR DESCRIPTION
Access to XNATs without username or password.

REST calls need a JSESSIONID even if a user isn't logged in, but that is taken by hitting the base XNAT URL (given by the server argument).
