### PR TITLE
Exception.message deprecated

### DIFF
--- a/pyxnat/core/interfaces.py
+++ b/pyxnat/core/interfaces.py
@@ -210,7 +210,7 @@ v           config: string
                 if is_xnat_error(self._jsession):
                     catch_error(self._jsession)
             except Exception, e:
-                if not '/data/JSESSION' in e.message:
+                if not '/data/JSESSION' in str(e):
                     raise e
             
         return self._entry


### PR DESCRIPTION
This warning is printed if authentication fails -- I str(e) solves the problem (and I hope it catches all of the e.messages you were looking for!).
