### PR TITLE
Update pyxnat/core/resources.py

### DIFF
--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1775,7 +1775,7 @@ class File(EObject):
         if not os.path.exists(os.path.dirname(dest)):
             os.makedirs(os.path.dirname(dest))
 
-        src = self.get()
+        src = self.get(dest)
 
         if src != dest:
             shutil.copy2(src, dest)


### PR DESCRIPTION
The get_copy() function makes a point of creating the 'dest' variable, but then doesn't pass it to get().
