### PR TITLE
Set file.get() to use a url-encoded URI

### DIFF
--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1746,7 +1746,7 @@ class File(EObject):
                 
             self._intf._http.cache.preset(_location)
 
-        self._intf._exec(self._absuri, 'GET')
+        self._intf._exec(self._uri, 'GET')
 
         return self._intf._http.cache.get_diskpath(
             '%s%s' % (self._intf._server, self._absuri)


### PR DESCRIPTION
`file.get()` was using a non-url-encoded URI to make a GET request of a resource. 

Rather than issuing the get request using `file._absuri` to request a resource,  I've set it to use `file._uri', which is url-encoded (i.e., uses %20 for spaces).

In the case where a user uploads a file with a space, scripts will be able to download the file properly.
