### PR TITLE
fixed super call in Resource.datatype()

### DIFF
--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -419,9 +419,12 @@ class EObject(object):
 
     def parent(self):
         uri = uri_grandparent(self._uri)
-        Klass = globals()[uri_nextlast(uri).title().rsplit('s', 1)[0]]
-
-        return Klass(uri, self._intf)
+        klass = uri_nextlast(uri).title().rsplit('s',1)[0]
+        if klass:
+            Klass = globals()[klass]
+            return Klass(uri, self._intf)
+        else:
+            return None
 
     def children(self, show_names=True):
         """ Returns the children levels of this element.

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -210,6 +210,14 @@ def test_last_modified():
 
     assert t1 != t2
 
+def test_subject1_parent():
+    project = central.select.project('nosetests')
+    assert subj_1.parent()._uri == project._uri
+
+def test_project_parent():
+    project = central.select.project('nosetests')
+    assert not project.parent()
+
 def test_subject1_delete():
     assert subj_1.exists()
     subj_1.delete()
@@ -229,6 +237,3 @@ def test_project_configuration():
     assert 'nosetests' in project.users()
     assert 'nosetests' in project.owners()
     assert project.user_role('nosetests') == 'owner'
-    
-
-    


### PR DESCRIPTION
Resource.datatype() was calling super(Reconstruction, self) yielding boom.
