### PR TITLE
interface in tests using one config file

### DIFF
--- a/pyxnat/tests/attributes_test.py
+++ b/pyxnat/tests/attributes_test.py
@@ -5,7 +5,7 @@ from .. import Interface
 
 _modulepath = os.path.dirname(os.path.abspath(__file__))
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 
 sid = uuid1().hex
 eid = uuid1().hex

--- a/pyxnat/tests/central.cfg
+++ b/pyxnat/tests/central.cfg
@@ -1,0 +1,1 @@
+{"password": "nose", "user": "nosetests", "cachedir": "/tmp", "server": "https://central.xnat.org"}

--- a/pyxnat/tests/custom_variables_test.py
+++ b/pyxnat/tests/custom_variables_test.py
@@ -1,8 +1,9 @@
+import os
 from uuid import uuid1
 
 from .. import Interface
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 project = central.select('/project/nosetests')
 
 variables = {'Subjects' : {'newgroup' : {'foo' : 'string', 'bar' : 'int'}}}

--- a/pyxnat/tests/experiments_tests.py
+++ b/pyxnat/tests/experiments_tests.py
@@ -4,7 +4,7 @@ from .. import Interface
 
 _modulepath = os.path.dirname(os.path.abspath(__file__))
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 
 def test_global_experiment_listing():
     assert central.array.experiments(project_id='CENTRAL_OASIS_CS', 

--- a/pyxnat/tests/interfaces_test.py
+++ b/pyxnat/tests/interfaces_test.py
@@ -1,7 +1,7 @@
-from uuid import uuid1
+import os
 from .. import Interface
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 central_anon = Interface('https://central.xnat.org', anonymous=True)
 
 def test_simple_object_listing():

--- a/pyxnat/tests/manage_test.py
+++ b/pyxnat/tests/manage_test.py
@@ -1,6 +1,7 @@
+import os
 from .. import Interface
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 
 notified = []
 

--- a/pyxnat/tests/provenance_test.py
+++ b/pyxnat/tests/provenance_test.py
@@ -1,8 +1,9 @@
+import os
 from uuid import uuid1
 
 from .. import Interface
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 project = central.select('/project/nosetests')
 
 prov = {

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -8,7 +8,7 @@ from .. import Interface
 
 _modulepath = os.path.dirname(os.path.abspath(__file__))
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 
 _id_set1 = {
     'sid':uuid1().hex,

--- a/pyxnat/tests/scans_tests.py
+++ b/pyxnat/tests/scans_tests.py
@@ -4,7 +4,7 @@ from .. import Interface
 
 _modulepath = os.path.dirname(os.path.abspath(__file__))
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 
 def test_global_scan_listing():
     assert central.array.scans(project_id='CENTRAL_OASIS_CS', 

--- a/pyxnat/tests/search_test.py
+++ b/pyxnat/tests/search_test.py
@@ -1,9 +1,10 @@
+import os
 from uuid import uuid1
 
 from .. import Interface
 from .. import jsonutil
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 search_name = uuid1().hex
 search_template_name = uuid1().hex
 

--- a/pyxnat/tests/user_and_project_management_test.py
+++ b/pyxnat/tests/user_and_project_management_test.py
@@ -1,6 +1,7 @@
+import os
 from .. import Interface
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 
 def test_users():
     assert isinstance(central.manage.users(), list)

--- a/pyxnat/tests/xpath_test.py
+++ b/pyxnat/tests/xpath_test.py
@@ -1,6 +1,7 @@
+import os
 from .. import Interface
 
-central = Interface('https://central.xnat.org', 'nosetests', 'nosetests')
+central = Interface(config=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'central.cfg'))
 
 def test_xpath_checkout():
     central.xpath.checkout(subjects=['OAS1_0001', 'OAS1_0002'])


### PR DESCRIPTION
Due to issue #59 I had to change the password in all tests. This pull request moves the credentials to one config file which is used by pyxnat.Interface in the tests.