### PR TITLE
Pyxnat convert from httplib2 to the python requests library

### DIFF
--- a/pyxnat/core/help.py
+++ b/pyxnat/core/help.py
@@ -83,7 +83,7 @@ class Inspector(object):
         self._intf._get_entry_point()
 
         search_els = self._get_json('%s/search/elements?format=json' % 
-                                        self._intf._entry)
+                                        self._intf._get_entry_point())
 
         if not fields_pattern and ('*' in pattern or '?' in pattern):       
             return get_column(search_els , 'ELEMENT_NAME', pattern)
@@ -101,7 +101,7 @@ class Inspector(object):
         self._intf._get_entry_point()
 
         search_fds = self._get_json('%s/search/elements/%s?format=json'
-                                        % (self._intf._entry, datatype)
+                                        % (self._intf._get_entry_point(), datatype)
                                     )
 
         fields = get_column(search_fds, 'FIELD_ID', pattern)
@@ -206,9 +206,7 @@ class Inspector(object):
             Parameters
             ----------
             datatype: string
-                An experiment type.
-            project: string
-                Optional. Restrict operation to a project.
+                An experiment type. eg: xnat:mrsessiondata
             project: string
                 Optional. Restrict operation to a project.
         """
@@ -237,7 +235,7 @@ class Inspector(object):
             Parameters
             ----------
             datatype: string
-                An experiment type.
+                An experiment type. eg: xnat:mrsessiondata
             project: string
                 Optional. Restrict operation to a project.
         """
@@ -501,7 +499,8 @@ class PaintGraph(object):
 
         nx.draw(graph, pos, labels=graph.labels, 
                 node_size=costs, node_color=costs,
-                font_size=13, font_color='orange', font_weight='bold'
+                font_size=13, font_color='orange', 
+                font_weight='bold', with_labels=True
                 )
     
         plt.axis('off')
@@ -567,7 +566,8 @@ class PaintGraph(object):
 
         nx.draw(graph, pos, 
                 node_size=node_size, node_color=node_color,
-                font_size=13, font_color='green', font_weight='bold'
+                font_size=13, font_color='green', font_weight='bold',
+                with_labels=True
                 )
     
         plt.axis('off')
@@ -591,7 +591,8 @@ class PaintGraph(object):
 
         nx.draw(graph, pos, 
                 node_size=costs, node_color=costs,
-                font_size=13, font_color='black', font_weight='bold'
+                font_size=13, font_color='black', 
+                font_weight='bold', with_labels=True
                 )
     
         plt.axis('off')

--- a/pyxnat/core/help.py
+++ b/pyxnat/core/help.py
@@ -330,18 +330,8 @@ class Inspector(object):
         return list(set(values))
 
     def _resource_struct(self, name):
-        kbase = {}
-
-        for kfile in glob.iglob('%s/*.struct' % self._intf._cachedir):
-            kdata = json.load(open(kfile, 'rb'))
-            if kdata == {}:
-                continue
-            if name in kdata.keys()[0]:
-                kbase.update(kdata)
-
-        self._intf._struct.update(kbase)
-
-        return kbase
+        
+        return self._intf._struct
     
     def _resource_types(self, name):
         return list(set(self._resource_struct(name).values()))

--- a/pyxnat/core/interfaces.py
+++ b/pyxnat/core/interfaces.py
@@ -217,10 +217,6 @@ class Interface(object):
             self._get_graph = GraphData(self)
             self.draw = PaintGraph(self)
 
-        if self._anonymous:
-            response, content = self._http.request(self._server, 'GET')
-            self._jsession = response['set-cookie'][:44]
-
         if self._interactive:
             self._get_entry_point()
 

--- a/pyxnat/core/interfaces.py
+++ b/pyxnat/core/interfaces.py
@@ -66,6 +66,11 @@ class Interface(object):
             Proxy support requires the socks module be installed. This can be
             installed via pip:
             pip install SocksiPy-branch
+
+        .. note:: 
+            Pyxnat-requests branch completely removes all of the caching 
+            functionality from pyxnat. The cache was causing more hassle than it was worth.
+
     """
 
     def __init__(self, server=None, user=None, password=None,
@@ -88,6 +93,10 @@ class Interface(object):
                 The user's password.
                 If None the user will be prompted for it.
             cachedir: string
+                .. note:: 
+                Pyxnat-requests branch completely removes all of the caching 
+                functionality from pyxnat.
+
                 Path of the cache directory (for all queries and
                 downloaded files)
                 If no path is provided, a platform dependent temp dir is
@@ -295,7 +304,7 @@ class Interface(object):
     def _exec(self, uri, method='GET', body=None, headers=None, force_preemptive_auth=False, **kwargs):
         """ A wrapper around a simple httplib2.request call that:
                 - avoids repeating the server url in the request
-                - deals with custom caching mechanisms
+                - deals with custom caching mechanisms :: Depricated
                 - manages a user session with cookies
                 - catches and broadcast specific XNAT errors
 
@@ -303,14 +312,28 @@ class Interface(object):
             ----------
             uri: string
                 URI of the resource to be accessed. e.g. /REST/projects
-            method: GET | PUT | POST | DELETE
+            method: GET | PUT | POST | DELETE | HEAD
                 HTTP method.
-            body: string
+            body: string | dict
                 HTTP message body
             headers: dict
                 Additional headers for the HTTP request.
             force_preemptive_auth: boolean
+                .. note:: Depricated with Pyxnat-requests
                 Indicates whether the request should include an Authorization header with basic auth credentials.
+            **kwargs: dictionary
+                Additional parameters to pass directly to the Requests HTTP call.
+
+            HTTP:GET
+            ----------
+                When calling with GET as method, the body parameter can be a key:value dictionary containing 
+                request parameters or a string of parameters. They will be url encoded and appended to the url.
+
+            HTTP:POST
+            ----------
+                When calling with POST as method, the body parameter can be a key:value dictionary containing 
+                request parameters they will be url encoded and appended to the url.
+
         """
 
         if headers is None:
@@ -337,6 +360,7 @@ class Interface(object):
             response = self._http.head(uri, headers=headers, data=body, **kwargs)
         else:
             print 'unsupported HTTP method'
+            return
 
         if (response is not None and not response.ok) or is_xnat_error(response.content):
             if DEBUG:

--- a/pyxnat/core/interfaces.py
+++ b/pyxnat/core/interfaces.py
@@ -292,7 +292,7 @@ class Interface(object):
         # if not self._anonymous:
         #    self._http.add_credentials(self._user, self._pwd)
 
-    def _exec(self, uri, method='GET', body=None, headers=None, force_preemptive_auth=False):
+    def _exec(self, uri, method='GET', body=None, headers=None, force_preemptive_auth=False, **kwargs):
         """ A wrapper around a simple httplib2.request call that:
                 - avoids repeating the server url in the request
                 - deals with custom caching mechanisms
@@ -326,15 +326,15 @@ class Interface(object):
         response = None
 
         if method is 'PUT':
-            response = self._http.put(uri, headers=headers, data=body)
+            response = self._http.put(uri, headers=headers, data=body, **kwargs)
         elif method is 'GET':
-            response = self._http.get(uri, headers=headers, params=body)
+            response = self._http.get(uri, headers=headers, params=body, **kwargs)
         elif method is 'POST':
-            response = self._http.post(uri, headers=headers, data=body)
+            response = self._http.post(uri, headers=headers, data=body, **kwargs)
         elif method is 'DELETE':
-            response = self._http.delete(uri, headers=headers, data=body)
+            response = self._http.delete(uri, headers=headers, data=body, **kwargs)
         elif method is 'HEAD':
-            response = self._http.head(uri, headers=headers, data=body)
+            response = self._http.head(uri, headers=headers, data=body, **kwargs)
         else:
             print 'unsupported HTTP method'
 

--- a/pyxnat/core/interfaces.py
+++ b/pyxnat/core/interfaces.py
@@ -136,11 +136,6 @@ class Interface(object):
             self._user = None
             self._pwd = None
 
-            self._cachedir = os.path.join(
-                cachedir, 'anonymous@%s' % self._server.split('//')[1].replace(
-                    '/', '.').replace(':', '_')
-            )
-
         else:
 
             if not all([server, user, password]) and not config:
@@ -159,13 +154,7 @@ class Interface(object):
                 self._server = connection_args['host']
                 self._user = connection_args['u']
                 self._pwd = connection_args['p']
-                self._cachedir = os.path.join(
-                    cachedir, '%s@%s' % (
-                        self._user,
-                        self._server.split('//')[1].replace(
-                            '/', '.').replace(':', '_')
-                    )
-                )
+                
 
                 if 'proxy' in connection_args:
                     self.__set_proxy(connection_args['proxy'])
@@ -189,14 +178,6 @@ class Interface(object):
 
                 self._user = user
                 self._pwd = password
-
-                self._cachedir = os.path.join(
-                    cachedir, '%s@%s' % (
-                        self._user,
-                        self._server.split('//')[1].replace(
-                            '/', '.').replace(':', '_')
-                    )
-                )
 
                 self.__set_proxy(proxy)
 
@@ -236,7 +217,6 @@ class Interface(object):
             '_server': self._server,
             '_user': self._user,
             '_pwd': self._pwd,
-            '_cachedir': os.path.split(self._cachedir)[0],
             '_anonymous': self._anonymous,
         }
 
@@ -245,7 +225,7 @@ class Interface(object):
         if self._anonymous:
             self.__init__(self._server, anonymous=True)
         else:
-            self.__init__(self._server, self._user, self._pwd, self._cachedir)
+            self.__init__(self._server, self._user, self._pwd)
 
     def __set_proxy(self, proxy=None):
         if proxy is None:
@@ -451,7 +431,6 @@ class Interface(object):
         config = {'server': self._server,
                   'user': self._user,
                   'password': self._pwd,
-                  'cachedir': os.path.split(self._cachedir)[0],
                   }
         if self._proxy_url:
             config['proxy'] = self._proxy_url.geturl()
@@ -484,16 +463,7 @@ class Interface(object):
             self._server = str(config['server'])
             self._user = str(config['user'])
             self._pwd = str(config['password'])
-            self._cachedir = str(config['cachedir'])
-
-            self._cachedir = os.path.join(
-                self._cachedir, '%s@%s' % (
-                    self._user,
-                    self._server.split('//')[1].replace(
-                        '/', '.').replace(':', '_')
-                )
-            )
-
+            
             if 'proxy' in config:
                 self.__set_proxy(str(config['proxy']))
             else:

--- a/pyxnat/core/interfaces.py
+++ b/pyxnat/core/interfaces.py
@@ -514,3 +514,51 @@ class Interface(object):
         """
         self._exec('/data/JSESSION', method='DELETE')
         pass
+
+    def get(self, uri, **kwargs):
+        '''
+        Wrapper around requests.get()
+        returns rquests.response object
+        '''
+        uri = join_uri(self._server, uri)
+        response = self._http.get(uri, **kwargs)
+        return response
+
+    def put(self, uri, **kwargs):
+        '''
+        Wrapper around requests.put()
+        returns rquests.response object
+        '''
+        uri = join_uri(self._server, uri)
+        response = self._http.put(uri, **kwargs)
+        return response
+
+    def post(self, uri, **kwargs):
+        '''
+        Wrapper around requests.post()
+        returns rquests.response object
+        '''
+        uri = join_uri(self._server, uri)
+        response = self._http.post(uri, **kwargs)
+        return response
+
+    def delete(self, uri, **kwargs):
+        '''
+        Wrapper around requests.delete()
+        returns rquests.response object
+        '''
+        uri = join_uri(self._server, uri)
+        response = self._http.delete(uri, **kwargs)
+        return response
+
+    def head(self, uri, **kwargs):
+        '''
+        Wrapper around requests.head()
+        returns rquests.response object
+        '''
+        uri = join_uri(self._server, uri)
+        response = self._http.head(uri, **kwargs)
+        return response
+
+
+

--- a/pyxnat/core/jsonutil.py
+++ b/pyxnat/core/jsonutil.py
@@ -127,7 +127,7 @@ class JsonTable(object):
                                       )
 
         return '<JsonTable %s:%s> %s' % (
-            len(self), len(self.headers()), _headers
+            len(self.data), len(self.headers()), _headers
             )
     
         # return ('[%s\n .\n .\n . \n%s]\n\n'

--- a/pyxnat/core/manage.py
+++ b/pyxnat/core/manage.py
@@ -100,24 +100,7 @@ class SchemaManager(object):
         self._intf = interface
         self._trees = {}
 
-    def _init(self):
-        if self._trees == {}:
-            cache_template = '%s/*.xsd.headers' % self._intf._cachedir
-
-            for entry in glob.iglob(cache_template):
-                hfp = open(entry, 'rb')
-                content = hfp.read()
-                hfp.close()
-
-                url = re.findall('(?<=content-location:\s%s)'
-                                 '.*?(?=\r{0,1}\n)' % self._intf._server, 
-                                 content)[0]
-
-                self._trees[url.split('/')[-1]] = \
-                    etree.fromstring(self._intf._exec(url))
-
     def __call__(self):
-        self._init()
         return self._trees.keys()
 
     def add(self, url):
@@ -133,7 +116,6 @@ class SchemaManager(object):
                     ``xnat.xsd``
 
         """
-        self._init()
         
         if not re.match('/?schemas/.*/.*\.xsd', url):
             if not 'schemas' in url and re.match('/?\w+/\w+[.]xsd', url):

--- a/pyxnat/core/pathutil.py
+++ b/pyxnat/core/pathutil.py
@@ -1,5 +1,6 @@
 import os
 
+
 def find_files(src):
     names = os.listdir(src)
 
@@ -21,3 +22,9 @@ def find_files(src):
             errors.append((srcname, str(why)))
 
     return files
+
+
+def ensure_dir_exists(dir_path):
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+    return os.path.isdir(dir_path)

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -37,7 +37,7 @@ from . import httputil
 from . import downloadutils
 
 
-DEBUG = True
+DEBUG = False
 
 # metaclasses
 
@@ -594,7 +594,8 @@ class CObject(object):
                     for item in self._filters.items()
                     )
 
-            print uri + query_string
+            if DEBUG:
+                print uri + query_string
             jtable = self._intf._get_json(uri + query_string)
 
             

--- a/pyxnat/tests/attributes_test.py
+++ b/pyxnat/tests/attributes_test.py
@@ -1,5 +1,6 @@
 import os
 from uuid import uuid1
+import time
 
 from .. import Interface
 
@@ -34,7 +35,8 @@ def test_attr_get():
     assert experiment.attrs.get('xnat:mrSessionData/age') == '42.0'
 
 def test_attr_mget():
-    fields = ['xnat:subjectData/investigator/firstname', 
+    time.sleep(5)
+    fields = ['xnat:subjectData/investigator/firstname',
               'xnat:subjectData/investigator/lastname'
               ]
 
@@ -45,6 +47,7 @@ def test_attr_set():
     assert experiment.attrs.get('xnat:mrSessionData/age') == '26.0'
 
 def test_attr_mset():
+
     field_data = {'xnat:subjectData/investigator/firstname':'angus',
                   'xnat:subjectData/investigator/lastname':'young',
                   }

--- a/pyxnat/tests/attributes_test.py
+++ b/pyxnat/tests/attributes_test.py
@@ -47,15 +47,17 @@ def test_attr_set():
     assert experiment.attrs.get('xnat:mrSessionData/age') == '26.0'
 
 def test_attr_mset():
-
+    subject = central.select.project('nosetests').subject(sid)
+    time.sleep(5)
     field_data = {'xnat:subjectData/investigator/firstname':'angus',
                   'xnat:subjectData/investigator/lastname':'young',
                   }
 
     subject.attrs.mset(field_data)
+    returned = subject.attrs.mget(field_data.keys())
 
-    assert set(subject.attrs.mget(field_data.keys())) == \
-        set(field_data.values())
+    assert set(returned) == \
+        set(field_data.values()), '''set: %s returned: %s ''' %(field_data.values(), returned)
 
 def test_cleanup():
     subject.delete()

--- a/pyxnat/tests/provenance_test.py
+++ b/pyxnat/tests/provenance_test.py
@@ -23,10 +23,11 @@ assessor = project.subject(sid).experiment(eid).assessor(
 
 
 def test_provenance():
+    assert assessor.exists()
     assessor.provenance.set(prov)
     _prov = assessor.provenance.get()[0]
 
-    assert prov['program'] == _prov['program']
+    assert prov['program'] == _prov['program'], "Subject: %s Study: %s Prov: %s" % (sid, eid, aid)
 
 # def test_del_provenance():
 #     assessor.provenance.delete()

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -240,7 +240,7 @@ def test_subject2_delete():
 def test_project_configuration():
     project = central.select('/project/nosetests')
     assert project.quarantine_code() == 0
-    assert project.prearchive_code() == 0
+    assert project.prearchive_code() == 4, project.prearchive_code()
     assert project.current_arc() == 'arc001'
     assert 'nosetests' in project.users()
     assert 'nosetests' in project.owners()

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -144,8 +144,6 @@ def test_put_file():
 def test_get_file():
     fh = subj_1.resource('test').file('hello.txt')
 
-    central.cache.set_usage(expiration=0)
-
     fpath = fh.get()
     assert os.path.exists(fpath)
     assert open(fpath, 'rb').read() == 'Hello XNAT!\n'
@@ -153,11 +151,9 @@ def test_get_file():
     custom = os.path.join(tempfile.gettempdir(), uuid1().hex)
     
     fh.get(custom)
-    assert os.path.exists(custom)
-    assert not os.path.exists(fpath)
-    fh.get()
-    assert os.path.exists(custom)
+    assert os.path.exists(custom), "fpath: %s custom: %s" % (fpath, custom)
     os.remove(custom)
+    os.remove(fpath)
 
 def test_put_dir_file():
     local_path = os.path.join(_modulepath, 'hello_again.txt')
@@ -169,8 +165,6 @@ def test_put_dir_file():
 def test_get_dir_file():
     fh = subj_1.resource('test').file('dir/hello.txt')
 
-    central.cache.set_usage(expiration=0)
-
     fpath = fh.get()
     assert os.path.exists(fpath)
     assert open(fpath, 'rb').read() == 'Hello again!\n'
@@ -178,11 +172,9 @@ def test_get_dir_file():
     custom = os.path.join(tempfile.gettempdir(), uuid1().hex)
     
     fh.get(custom)
-    assert os.path.exists(custom)
-    assert not os.path.exists(fpath)
-    fh.get()
-    assert os.path.exists(custom)
+    assert os.path.exists(custom), "fpath: %s custom: %s" % (fpath, custom)
     os.remove(custom)
+    os.remove(fpath)
 
 def test_get_copy_file():
     fpath = os.path.join(tempfile.gettempdir(), uuid1().hex)
@@ -193,7 +185,6 @@ def test_get_copy_file():
     fd.close()
     os.remove(fpath)
 
-    central.cache.set_usage(expiration=1)
 
 def test_file_last_modified():
     f = subj_1.resource('test').file('hello.txt')

--- a/pyxnat/tests/user_and_project_management_test.py
+++ b/pyxnat/tests/user_and_project_management_test.py
@@ -38,10 +38,10 @@ def test_project_user_role():
                                   ).user_role('nosetests') == 'owner'
 
 def test_add_remove_user():
-    central.select.project('nosetests').add_user('schwarty', 'collaborator')
-    assert 'schwarty' in central.select.project('nosetests').collaborators()
-    central.select.project('nosetests').remove_user('schwarty')
-    assert 'schwarty' not in central.select.project('nosetests'
+    central.select.project('nosetests').add_user('nosetests3', 'collaborator')
+    assert 'nosetests3' in central.select.project('nosetests').collaborators()
+    central.select.project('nosetests').remove_user('nosetests3')
+    assert 'nosetests3' not in central.select.project('nosetests'
                                                     ).collaborators()
 
 def test_project_accessibility():

--- a/setup.py
+++ b/setup.py
@@ -67,5 +67,5 @@ setup(name='pyxnat',
 
       platforms='any', 
       requires=['requests'],
-      install_requires=['requests', 'lxml'],
+      install_requires=['requests', 'lxml', 'requests[security]'],
       **extra_setuptools_args)

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,7 @@ setup(name='pyxnat',
           'Topic :: Internet :: WWW/HTTP',
       ],
 
-      platforms='any', requires=['httplib2'],
+      platforms='any', 
+      requires=['requests'],
+      install_requires=['requests', 'lxml'],
       **extra_setuptools_args)


### PR DESCRIPTION
Convert pyxnat from httplib2 to python requests library for handling all http calls:

* Remove all caching (but leave references for backward compatibility)
* non-specified downloads now save to ~/Downloads/ by default instead of /tmp.  Although better to use get(/to/here)
* Convenience methods for http interface: get/put/post/delete
* more informational error messages
* Streaming file downloads 
* Streaming file uploads
* Verify https certificates.
* Fixed a bunch of tests.