### PR TITLE
Added option to scans.download() to delete zip file

### DIFF
--- a/pyxnat/core/downloadutils.py
+++ b/pyxnat/core/downloadutils.py
@@ -39,7 +39,7 @@ def unzip(fzip,
     return (True, map(lambda f: os.path.join(dest_dir, f), fzip.namelist()))
 
 
-def download(dest_dir, instance=None, type="ALL", name=None, extract=False, safe=False):
+def download(dest_dir, instance=None, type="ALL", name=None, extract=False, safe=False, removeZip=False):
     """
     Download all the files at this level that match the given constraint as a zip archive. Should not be called directly
     but from a instance of class that supports bulk downloading eg. "Scans"
@@ -166,6 +166,9 @@ def download(dest_dir, instance=None, type="ALL", name=None, extract=False, safe
             fzip.close()
             raise EnvironmentError("Unable to extract " + zip_location + " because file " + paths + " failed the following test: " + check['desc'])
         else:
+            if removeZip:
+                      fzip.close()
+                      os.remove(zip_location)
             return paths
     else:
         fzip.close()

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -2079,37 +2079,37 @@ class Assessors(CObject):
             eobj.unshare(project)
 
     def download(self, dest_dir, type="ALL",
-                 name=None, extract=False, safe=False):
+                 name=None, extract=False, safe=False, removeZip=False):
         """
         A wrapper around :func:`downloadutils.download`
         """
         return downloadutils.download(dest_dir, self, type, name,
-                                      extract, safe)
+                                      extract, safe, removeZip)
 
 
 class Reconstructions(CObject):
     __metaclass__ = CollectionType
 
     def download(self, dest_dir, type="ALL",
-                 name=None, extract=False, safe=False):
+                 name=None, extract=False, safe=False, removeZip=False):
         """
         A wrapper around :func:`downloadutils.download`
         """
         return downloadutils.download(dest_dir, self, type, name,
-                                      extract, safe)
+                                      extract, safe, removeZip)
 
 
 class Scans(CObject):
     __metaclass__ = CollectionType
 
     def download(self, dest_dir, type="ALL",
-                 name=None, extract=False, safe=False):
+                 name=None, extract=False, safe=False, removeZip=False):
         """
         A wrapper around :func:`downloadutils.download`
 
         """
         return downloadutils.download(dest_dir, self, type, name,
-                                      extract, safe)
+                                      extract, safe, removeZip)
 
 
 class Resources(CObject):


### PR DESCRIPTION
Added option to the scans.download() function to delete the downloaded zip file after extraction. Seems to work, but there might be some exceptions?
Only deletes the zip if extract is set to True.