### PR TITLE
Pass keyword arguments in some methods down to requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 *.DS_Store*
 .project
 .pydevproject
+.idea

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,19 @@
 Latest changes
 ===============
 
+Release 1.0.1.0
+---------------
+
+    * New Features
+
+    * Improvements
+        - Pass keyword arguments on some put/create methods, to allow passing event_reason.
+
+    * Bug fixes:
+
+
 Release 1.0.0.0
+---------------
 
     * New Features
         - Convenience methods on interface: get, put, post, delete, head
@@ -14,9 +26,10 @@ Release 1.0.0.0
         - Use the requests library instead of httplib2 for REST calls
 
     * Bug fixes:
-        - Removed custom httplib2 caching. 
+        - Removed custom httplib2 caching.
 
 Release 0.9.5.2
+-------------
 
     * New Features
 
@@ -27,6 +40,7 @@ Release 0.9.5.2
         - Tiekct #52 fix zip file downloading.
 
 Release 0.9.5
+-------------
 
     * New Features
         - Add __getitem__ to CObject for slice operations.
@@ -43,6 +57,7 @@ Release 0.9.5
 
 
 Release 0.9.4
+-------------
 
     * New Features
         - add proxy support to interface.

--- a/pyxnat/core/attributes.py
+++ b/pyxnat/core/attributes.py
@@ -58,7 +58,7 @@ class EAttrs(object):
 
         return self._id
 
-    def set(self, path, value):
+    def set(self, path, value, **kwargs):
         """ Set an attribute.
 
             Parameters
@@ -80,9 +80,9 @@ class EAttrs(object):
                                                          , urllib.quote(value)
                                               )
 
-        self._intf._exec(put_uri, 'PUT')
+        self._intf._exec(put_uri, 'PUT', **kwargs)
 
-    def mset(self, dict_attrs):
+    def mset(self, dict_attrs, **kwargs):
         """ Set multiple attributes at once.
 
             It is more efficient to use this method instead of
@@ -106,7 +106,7 @@ class EAttrs(object):
 
         put_uri = self._eobj._uri + query_str
 
-        self._intf._exec(put_uri, 'PUT')
+        self._intf._exec(put_uri, 'PUT', **kwargs)
 
     def get(self, path):
         """ Get an attribute value.

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -375,7 +375,7 @@ class EObject(object):
         if DEBUG:
             print('PUT', create_uri)
 
-        output = self._intf._exec(create_uri, 'PUT')
+        output = self._intf._exec(create_uri, 'PUT', **params)
 
         if is_xnat_error(output):
             paths = []
@@ -1706,7 +1706,7 @@ class Resource(EObject):
             do_extract = ''
 
         self.file(os.path.split(zip_location)[1] + do_extract
-                  ).put(zip_location, overwrite=overwrite)
+                  ).put(zip_location, overwrite=overwrite, **datatypes)
 
     def put_dir(self, src_dir, overwrite=False, extract=True, **datatypes):
         """ Finds recursively all the files in a folder and uploads


### PR DESCRIPTION
This allows more methods to pass `event_reason`, which is required for `PUT`/`POST` on XNAT CR.

This is an alternative to #71.