### PR TITLE
Replace '\n' end-line chars by an OS-agnostic alternative

### DIFF
--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -146,7 +146,7 @@ def test_get_file():
 
     fpath = fh.get()
     assert os.path.exists(fpath)
-    assert open(fpath, 'rb').read() == 'Hello XNAT!\n'
+    assert open(fpath, 'rb').read() == 'Hello XNAT!%s' % os.linesep
 
     custom = os.path.join(tempfile.gettempdir(), uuid1().hex)
     
@@ -167,7 +167,7 @@ def test_get_dir_file():
 
     fpath = fh.get()
     assert os.path.exists(fpath)
-    assert open(fpath, 'rb').read() == 'Hello again!\n'
+    assert open(fpath, 'rb').read() == 'Hello again!%s' % os.linesep
 
     custom = os.path.join(tempfile.gettempdir(), uuid1().hex)
     
@@ -181,7 +181,7 @@ def test_get_copy_file():
     fpath = subj_1.resource('test').file('hello.txt').get_copy(fpath)
     assert os.path.exists(fpath)
     fd = open(fpath, 'rb')
-    assert fd.read() == 'Hello XNAT!\n'
+    assert fd.read() == 'Hello XNAT!%s' % os.linesep
     fd.close()
     os.remove(fpath)
 


### PR DESCRIPTION
This PR replaces Unix-based '\n' end-liners by an OS-agnostic alternative (via os module), making the text comparison assertions (and thus the resource-related tests) more resilient to unrelated errors. 