### PR TITLE
ArrayData class main methods

### DIFF
--- a/pyxnat/core/array.py
+++ b/pyxnat/core/array.py
@@ -8,7 +8,7 @@ class ArrayData(object):
     def _get_array(self, query_string, project_id=None,
                    subject_id=None, subject_label=None,
                    experiment_id=None, experiment_label=None,
-                   experiment_type='xnat:imageSessionData',
+                   experiment_type='xnat:subjectAssessorData',
                    columns=None, constraints=None
                    ):
 
@@ -53,7 +53,7 @@ class ArrayData(object):
 
     def experiments(self, project_id=None, subject_id=None, subject_label=None,
               experiment_id=None, experiment_label=None,
-              experiment_type='xnat:mrSessionData',
+              experiment_type='xnat:subjectAssessorData',
               columns=None,
               constraints=None
               ):
@@ -90,10 +90,42 @@ class ArrayData(object):
                                experiment_type, columns, constraints
                                )
 
+    def mrsessions(self, project_id=None, subject_id=None, subject_label=None,
+              experiment_id=None, experiment_label=None,
+              columns=None,
+              constraints=None
+              ):
+
+        """ Returns a list of all MR sessions, filtered by optional constraints.
+
+            Parameters
+            ----------
+            project_id: string
+                Name pattern to filter by project ID.
+            subject_id: string
+                Name pattern to filter by subject ID.
+            subject_label: string
+                Name pattern to filter by subject ID.
+            experiment_id: string
+                Name pattern to filter by experiment ID.
+            experiment_label: string
+                Name pattern to filter by experiment ID.
+            columns: list
+                Values to return.
+            constraints: dict
+                Dictionary of xsi_type (key--) and parameter (--value)
+                pairs by which to filter.
+            """
+
+        return self.experiments(project_id, subject_id, subject_label,
+                                experiment_id, experiment_label,
+                                'xnat:mrSessionData', columns, constraints
+                                )
+
     def scans(self, project_id=None, subject_id=None, subject_label=None,
               experiment_id=None, experiment_label=None,
-              experiment_type='xnat:mrSessionData',
-              scan_type='xnat:mrScanData',
+              experiment_type='xnat:imageSessionData',
+              scan_type='xnat:imageScanData',
               columns=None,
               constraints=None
               ):
@@ -132,12 +164,45 @@ class ArrayData(object):
                                experiment_id, experiment_label,
                                experiment_type, columns, constraints
                                )
+        
+    def mrscans(self, project_id=None, subject_id=None, subject_label=None,
+                experiment_id=None, experiment_label=None,
+                columns=None,
+                constraints=None
+                ):
+
+        """ Returns a list of all MR scans, filtered by optional constraints.
+
+            Parameters
+            ----------
+            project_id: string
+                Name pattern to filter by project ID.
+            subject_id: string
+                Name pattern to filter by subject ID.
+            subject_label: string
+                Name pattern to filter by subject ID.
+            experiment_id: string
+                Name pattern to filter by experiment ID.
+            experiment_label: string
+                Name pattern to filter by experiment ID.
+            columns: list
+                Values to return.
+            constraints: dict
+                Dictionary of xsi_type (key--) and parameter (--value)
+                pairs by which to filter.
+            """
+
+        return self.scans(project_id, subject_id, subject_label,
+                          experiment_id, experiment_label,
+                          'xnat:mrSessionData', 'xnat:mrScanData',
+                          columns, constraints
+                          )
 
     def search_experiments(self,
                            project_id=None,
                            subject_id=None,
                            subject_label=None,
-                           experiment_type='xnat:mrSessionData',
+                           experiment_type='xnat:subjectAssessorData',
                            columns=None,
                            constraints=None
                            ):

--- a/pyxnat/core/array.py
+++ b/pyxnat/core/array.py
@@ -159,12 +159,14 @@ class ArrayData(object):
         query_string = '&columns=ID,project,%s/subject_id,%s/ID' % (
             experiment_type, scan_type)
 
-        return self._get_array(query_string, project_id,
+        array = self._get_array(query_string, project_id,
                                subject_id, subject_label,
                                experiment_id, experiment_label,
                                experiment_type, columns, constraints
                                )
-        
+        id_key = ('%s/ID' % scan_type).lower()
+        return JsonTable([i for i in array if i[id_key]])
+
     def mrscans(self, project_id=None, subject_id=None, subject_label=None,
                 experiment_id=None, experiment_label=None,
                 columns=None,
@@ -207,7 +209,7 @@ class ArrayData(object):
                            constraints=None
                            ):
 
-        """ Returns a list of all visible experiment IDs of the 
+        """ Returns a list of all visible experiment IDs of the
             specified type, filtered by optional constraints. This
             function is a shortcut using the search engine.
 
@@ -220,7 +222,7 @@ class ArrayData(object):
             subject_label: string
                 Name pattern to filter by subject ID.
             experiment_type: string
-                xsi path type must be a leaf session type. 
+                xsi path type must be a leaf session type.
                 defaults to 'xnat:mrSessionData'
             columns: List[string]
                 list of xsi paths for names of columns to return.

--- a/pyxnat/tests/array_test.py
+++ b/pyxnat/tests/array_test.py
@@ -1,0 +1,57 @@
+import unittest
+from pyxnat import Interface
+
+import logging as log
+log.basicConfig(level=log.INFO)
+
+class ArrayTests(unittest.TestCase):
+    ''' Resource-related XNAT connectivity test cases '''
+
+    def setUp(self):
+        self._interface = Interface(config='.xnat.cfg')
+
+    def test_array_experiments(self):
+        '''
+        Get a list of experiments from a given subject which has multiple types
+        of experiments (i.e. MRSessions and PETSessions) and assert it gathers
+        them all.
+        '''
+
+        e = self._interface.array.experiments(subject_id='BBRCDEV_S00245').data
+        self.assertGreaterEqual(len(e),3)
+
+    def test_array_mrsessions(self):
+        '''
+        From a given subject which has multiple types of experiments, get a list
+        of MRI sessions and assert its length matches the list of experiments of
+        type 'xnat:mrSessionData'
+        '''
+
+        mris = self._interface.array.mrsessions(subject_id='BBRCDEV_S00245').data
+        exps = self._interface.array.experiments(subject_id='BBRCDEV_S00245',
+                                                 experiment_type='xnat:mrSessionData'
+                                                 ).data
+        self.assertListEqual(mris,exps)
+
+    def test_array_scans(self):
+        '''
+        Get a list of scans from a given experiment which has multiple types
+        of scans (i.e. PETScans and CTScans) and assert it gathers them all.
+        '''
+
+        s = self._interface.array.scans(experiment_id='BBRCDEV_E00745').data
+        self.assertEqual(len(s),3)
+
+    def test_array_mrscans(self):
+        '''
+        Get a list of MRI scans from a given experiment which has multiple scans
+        mixed (i.e. MRScans and MRSpectroscopies, aka OtherDicomScans) and
+        assert its length matches the list of scans filtered by type 'xnat:mrScanData'
+        '''
+
+        mris = self._interface.array.mrscans(experiment_id='BBRCDEV_E00398').data
+        exps = self._interface.array.scans(experiment_id='BBRCDEV_E00398',
+                                           scan_type='xnat:mrScanData'
+                                           ).data
+        self.assertListEqual([i['xnat:mrscandata/id'] for i in mris],
+                             [i['xnat:mrscandata/id'] for i in exps])


### PR DESCRIPTION
`ArrayData()` class methods `experiments()` and `scans()` have several inconsistencies which might affect their reliability when used by non-experienced users.

1.  By default the type of queried entities is set to `xnat:mrSessionData` or `xnat:mrScanData` when querying for lists of experiments or scans respectively. That can rise some undesired problems if not known and function results could be inaccurate. This PR fixes that by switching to a more conservative catch-all default values and adding additional MR-specific alternatives. 
2.  `scans()` method is not capable of filtering result entries by `scan_type` argument value when specified. Instead, a list of all existing scans is returned -no matter which type are they of- but with blank `scan_type`-specific attributes. This behavior might rise some inconsistencies at processing the `scans()` method results and I've considered a better approach to refactor its output results by excluding those scans whose type is not matching the requested one (or derivatives). Perhaps a more radical approach should be taken redesigning the inner calls to the REST API used. 
Example (experiment with a CT scan and a PET scan, note that 'xnat:petscandata/id' is empty for the former scan):
```python
interface.array.scans(experiment_id='BBRCDEV_E00999',scan_type='xnat:petScanData').data

[{'ID': 'BBRCDEV_E00999',
  'URI': '/data/experiments/BBRCDEV_E00999',
  'project': 'testenv',
  'session_ID': 'BBRCDEV_E00999',
  'xnat:imagesessiondata/subject_id': 'BBRCDEV_S00999',
  'xnat:petscandata/id': '',
  'xsiType': 'xnat:petSessionData'},
 {'ID': 'BBRCDEV_E00999',
  'URI': '/data/experiments/BBRCDEV_E00999',
  'project': 'testenv',
  'session_ID': 'BBRCDEV_E00999',
  'xnat:imagesessiondata/subject_id': 'BBRCDEV_S00999',
  'xnat:petscandata/id': '5',
  'xsiType': 'xnat:petSessionData'}]
```
  however:
```python
interface.array.scans(experiment_id='BBRCDEV_E00999',scan_type='xnat:imageScanData').data

[{'ID': 'BBRCDEV_E00999',
  'URI': '/data/experiments/BBRCDEV_E00999',
  'project': 'testenv',
  'session_ID': 'BBRCDEV_E00999',
  'xnat:imagesessiondata/subject_id': 'BBRCDEV_S00999',
  'xnat:imagescandata/id': '3',
  'xsiType': 'xnat:petSessionData'},
 {'ID': 'BBRCDEV_E00999',
  'URI': '/data/experiments/BBRCDEV_E00999',
  'project': 'testenv',
  'session_ID': 'BBRCDEV_E00999',
  'xnat:imagesessiondata/subject_id': 'BBRCDEV_S00999',
  'xnat:imagescandata/id': '5',
  'xsiType': 'xnat:petSessionData'}]
```
3.  Last but not least, a set of `ArrayData`-specific tests were created for the main methods in the class.
