### PR TITLE
FIX: XNATException doesn't exist in pyxnat

### DIFF
--- a/pyxnat/core/interfaces.py
+++ b/pyxnat/core/interfaces.py
@@ -555,11 +555,7 @@ class Interface(object):
         '''
         uri = '/data/JSESSION'
         response = self.delete(uri)
-
-        if response.status_code != requests.codes.ok:
-            raise XNATException('HTTP response: #%s%s%s' \
-                % (response.status_code, os.linesep, response.content))
-
+        response.raise_for_status()
         self._jsession = None
 
     def __exit__(self, type, value, traceback):


### PR DESCRIPTION
This PR mainly addresses the invalid usage of `XNATException` class which is not defined in the code.
Alternatively, proposes using existing native `requests` package methods (`raise_for_status()`) for handling failed responses based on their HTTP status codes ‒instead of the existing code fragment.

Thanks for reviewing and considering this PR.