### PR TITLE
ENH: supress the security vulnerability alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lxml==2.3.2
-requests=2.1.0
+lxml>=2.3.2
+requests>=2.2.0


### PR DESCRIPTION
Updated `requirements.txt` file requiring an updated version of the `requests` package for security purposes (see [here](https://nvd.nist.gov/vuln/detail/CVE-2018-18074)). 

Also enforces using recent-ish versions of required packages rather than forcing an specific one.