### PR TITLE
Make SchemaManager compatible with XNAT 1.7+

### DIFF
--- a/pyxnat/core/attributes.py
+++ b/pyxnat/core/attributes.py
@@ -45,7 +45,6 @@ class EAttrs(object):
         """ List the attributes paths relevant to this element.
         """
         paths = []
-        self._intf.manage.schemas._init()
         for root in self._intf.manage.schemas._trees.values():
             paths.extend(datatype_attributes(root, self._get_datatype()))
         return paths

--- a/pyxnat/core/manage.py
+++ b/pyxnat/core/manage.py
@@ -112,20 +112,19 @@ class SchemaManager(object):
             url: str
                 url of the schema relative to the server.
                     e.g. for
-                    http://central.xnat.org/schemas/xnat/xnat.xsd give
-                    ``schemas/xnat/xnat.xsd`` or even only
-                    ``xnat.xsd``
+                    http://central.xnat.org/xapi/schemas/xnat give
+                    ``/xapi/schemas/xnat``
 
         """
 
-        if not re.match('/?schemas/.*/.*\.xsd', url):
-            if not 'schemas' in url and re.match('/?\w+/\w+[.]xsd', url):
-                url = join_uri('/schemas', url)
-
-            elif not re.match('^[^/].xsd', url):
-                url = '/schemas/%s/%s'%(url.split('.xsd')[0], url)
-            else:
-                raise NotImplementedError
+        #if not re.match('/?schemas/.*/.*\.xsd', url):
+        #    if not 'schemas' in url and re.match('/?\w+/\w+[.]xsd', url):
+        #        url = join_uri('/schemas', url)
+        #
+        #    elif not re.match('^[^/].xsd', url):
+        #        url = '/schemas/%s/%s'%(url.split('.xsd')[0], url)
+        #    else:
+        #        raise NotImplementedError
 
         self._trees[url.split('/')[-1]] = \
             etree.fromstring(self._intf._exec(url))

--- a/pyxnat/tests/attributes_test.py
+++ b/pyxnat/tests/attributes_test.py
@@ -64,3 +64,32 @@ def test_attr_set():
 def test_cleanup():
     subject.delete()
     assert not subject.exists()
+
+def test_list_project_attrs():
+    project_attributes = ['xnat:projectData/name',
+                          'xnat:projectData/type',
+                          'xnat:projectData/description',
+                          'xnat:projectData/keywords',
+                          'xnat:projectData/aliases',
+                          'xnat:projectData/aliases/alias',
+                          'xnat:projectData/aliases/alias/None',
+                          'xnat:projectData/publications',
+                          'xnat:projectData/publications/publication',
+                          'xnat:projectData/resources',
+                          'xnat:projectData/resources/resource',
+                          'xnat:projectData/studyProtocol',
+                          'xnat:projectData/PI',
+                          'xnat:projectData/investigators',
+                          'xnat:projectData/investigators/investigator',
+                          'xnat:projectData/fields',
+                          'xnat:projectData/fields/field',
+                          'xnat:projectData/fields/field/None']
+
+    p = central.select.project('nosetests')
+    assert(p.attrs() == [])
+
+    central.manage.schemas.add('xapi/schemas/xnat')
+    p = central.select.project('nosetests')
+    assert (p.attrs() == project_attributes)
+
+

--- a/pyxnat/tests/manage_test.py
+++ b/pyxnat/tests/manage_test.py
@@ -20,3 +20,7 @@ def test_unregister_callback():
     central.manage.unregister_callback()
     assert central._callback is None
 
+def test_add_schema():
+    assert(len(central.manage.schemas()) == 0)
+    central.manage.schemas.add(url='/xapi/schemas/xnat')
+    assert(list(central.manage.schemas()) == ['xnat'])


### PR DESCRIPTION
Since XNAT 1.7 the schema-related REST API resources had been migrated to a new location in the new API (`XAPI`). This change was not supported by `pyxnat` which still expected schemas to be available in the same old location. See: https://github.com/pyxnat/pyxnat/blob/11e89b4587b486a15fb293ae240bdb2720f8f639/pyxnat/core/manage.py#L121-L128

This PR contains 2 changes, 
* Disable schema URL parsing/composition based on old location of schemas in the REST API when adding a new schema to a `SchemaManager` instance. This _smart_ URL composition made feature fail when pointing at 1.7+ XNAT instance.
* Remove old/legacy call to SchemaManager `_init()` method which made `EAttrs` class features fail. Note that the aforementioned method does not exist and `SchemaManager` instances are initialized properly by its class constructor. 

This PR includes a couple of simple tests -both for SchemaManager and EAtts affected classes. 

This PR fixes #101.