### PR TITLE
FIX: Python 3 `requests` responses return a bytes object, decode it

### DIFF
--- a/pyxnat/core/errors.py
+++ b/pyxnat/core/errors.py
@@ -65,6 +65,9 @@ def parse_put_error_message(message):
 
 def catch_error(msg_or_exception, full_response=None):
 
+    if isinstance(msg_or_exception, bytes):
+        msg_or_exception = msg_or_exception.decode()
+
     # handle errors returned by the xnat server
     if isinstance(msg_or_exception, (str, unicode)):
         # parse the message


### PR DESCRIPTION
This PR fixes #106 