### PR TITLE
Download resources under WinOS

### DIFF
--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -13,6 +13,9 @@ import codecs
 from fnmatch import fnmatch
 from itertools import islice
 from lxml import etree
+from pathlib import Path
+
+
 from .uriutil import join_uri, translate_uri, uri_segment
 from .uriutil import uri_last, uri_nextlast
 from .uriutil import uri_parent, uri_grandparent
@@ -1649,8 +1652,8 @@ class Resource(EObject):
         fzip.close()
 
         members = []
-
-        for member in fzip.namelist():
+        fzip_namelist = [str(Path(item)) for item in fzip.namelist()]
+        for member in fzip_namelist:
             old_path = op.join(dest_dir, member)
             if DEBUG:
                 print(member)
@@ -1669,7 +1672,7 @@ class Resource(EObject):
             members.append(new_path)
 
         # TODO: cache.delete(...)
-        for extracted in fzip.namelist():
+        for extracted in fzip_namelist:
             pth = op.join(dest_dir, extracted.split(os.sep, 1)[0])
 
             if op.isdir(pth):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ lxml>=4.3.2
 requests>=2.20
 future>=0.16
 pandas>=0.24
+pathlib==1.0.1


### PR DESCRIPTION
Closes #128

Use pathlib (standard library since python 3.4) to align all unzipped files to the OS-specific path format. 