### PR TITLE
Close open file handle and format date as ISO 8601

### DIFF
--- a/pyxnat/core/derivatives/dicom.py
+++ b/pyxnat/core/derivatives/dicom.py
@@ -10,7 +10,8 @@ def scandate(self):
     f = list(self.files())[0]
 
     fp = op.join(tempfile.gettempdir(), 'test.dcm')
-    _, fp = tempfile.mkstemp(suffix='.dcm')
+    fd, fp = tempfile.mkstemp(suffix='.dcm')
+    os.close(fd)
     f.get(dest=fp)
     d = pydicom.read_file(fp)
 
@@ -20,5 +21,5 @@ def scandate(self):
         acquisition_date = d.AcquisitionDateTime[:8]
 
     os.remove(fp)
-    ad = datetime.strptime(acquisition_date, '%Y%m%d').strftime('%m-%d-%Y')
+    ad = datetime.strptime(acquisition_date, '%Y%m%d').strftime('%Y-%m-%d')
     return ad


### PR DESCRIPTION
This PR includes 2 minor changes 
* Close the file handle opened by `tempfile.mkstemp()` to avoid a `PermissionError` exception (WinError) 
* Format `AcquisitionDate` value following the ISO 8601 standard date format recommendation