### PR TITLE
Object representation improvements 

### DIFF
--- a/pyxnat/core/attributes.py
+++ b/pyxnat/core/attributes.py
@@ -125,17 +125,16 @@ class EAttrs(object):
             A string containing the value.
         """
         query_str = '?columns=ID,%s' % path
-
         get_uri = uri_parent(self._eobj._uri) + query_str
-        jdata = JsonTable(self._intf._get_json(get_uri)
-                          ).where(ID=self._get_id())
+
+        jdata = JsonTable(self._intf._get_json(get_uri))
+        jdata = jdata.where(ID=self._get_id())
 
         # unfortunately the return headers do not always have the
         # expected name
 
         header = difflib.get_close_matches(path.split('/')[-1],
-                                           jdata.headers()
-                                           )
+                                           jdata.headers())
 
         if header == []:
             header = difflib.get_close_matches(path, jdata.headers())[0]

--- a/pyxnat/core/attributes.py
+++ b/pyxnat/core/attributes.py
@@ -58,10 +58,7 @@ class EAttrs(object):
         return self._datatype
 
     def _get_id(self):
-        if self._id is None:
-            self._id = self._eobj.id()
-
-        return self._id
+        return self._eobj.id()
 
     def set(self, path, value, **kwargs):
         """ Set an attribute.

--- a/pyxnat/core/help.py
+++ b/pyxnat/core/help.py
@@ -89,9 +89,8 @@ class Inspector(object):
         else:
             fields = []
             for datatype in get_column(search_els, 'ELEMENT_NAME', pattern):
-                fields.extend(self._datafields(datatype,
-                                               fields_pattern or '*', True)
-                              )
+                df = self._datafields(datatype, fields_pattern or '*', True)
+                fields.extend(df)
 
             return fields
 

--- a/pyxnat/core/jsonutil.py
+++ b/pyxnat/core/jsonutil.py
@@ -141,7 +141,7 @@ class JsonTable(object):
         #     return str(self.data[0])
 
         if len(self.headers()) <= 5:
-            _headers = ','.join(list(self.headers()))
+            _headers = self.headers()
         else:
             _headers = '%s ... %s' % (','.join(list(self.headers())[:2]),
                                       ','.join(list(self.headers())[-2:])

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1491,7 +1491,7 @@ class Subject(EObject):
                            'xnat:subjectData/ADD_IDS',
                            'xnat:subjectData/RACE',
                            'xnat:subjectData/ETHNICITY',
-                           'xnat:subjectData/XNAT_COL_SUBJECTDATALABEL']
+                           'xnat:subjectData/SUBJECT_LABEL']
 
                 dt = 'xnat:subjectData'
                 data = interface.select(dt, columns=columns).all().data
@@ -1507,7 +1507,7 @@ class Subject(EObject):
             age = self.attrs.get('age')
             gender = data['gender_text']
             handedness = data['handedness_text']
-            label = data['xnat_col_subjectdatalabel']
+            label = data['subject_label']
             n_expes = len(list(self.experiments()))
 
             ag = ''

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1045,10 +1045,9 @@ class Project(EObject):
             data = interface.select('xnat:projectData').all().data
             data = [e for e in data if e['id'] == project_id][0]
 
-            # Collecting projects details
+            # Collecting project details
             name = data['name']
 
-            # Fetch data subjects
             n_subjects = len(list(self.subjects()))
 
             # Creating the project url
@@ -1587,13 +1586,11 @@ class Experiment(EObject):
             insert_date = data['insert_date']
             n_res = len(list(self.resources()))
 
-            # Fetch data scans
             n_scans = len(list(self.scans()))
 
-            # Creating the project url
             url = intf._server + self._uri + '?format=html'
 
-            # Creating the output string to be returned
+            # Creating the output string
             output = '<{cl} Object> {id} `{label}` (subject: {subject_id} '\
                      '`{subject_label}`) (project: {project}) {n_scans} '\
                      'scan{final_s1} {n_res} resource{final_s2} (created on '\
@@ -1765,18 +1762,17 @@ class Scan(EObject):
     def __repr__(self):
         interface = self._intf
 
-        # Check if subject exists
+        # Check if scan exists
         if self.exists():
             scan_id = self.id()
 
-            # Fetch data scan
+            # Collect scan details
             attrs = ['type', 'frames', 'quality']
             sc_type, n_frames, quality = self.attrs.mget(attrs)
 
-            # Creating the project url
             url = interface._server + self._uri + '?format=html'
 
-            # Creating the output string to be returned
+            # Creating the output string
             output = '<{cl} Object> {id} (`{type}` {n_frames} frames) {quality} {url}'
             output = output.format(cl=self.__class__.__name__,
                                    id=scan_id,
@@ -1828,7 +1824,7 @@ class Resource(EObject):
                         if r['xnat_abstractresource_id'] == resource_id][0]
             fs = sizeof_fmt(float(res_info['file_size']))
 
-            # Creating the output string to be returned
+            # Creating the output string
             output = '<{cl} Object> {id} `{label}` ({fc} files {fs})'
             output = output.format(label=self.label(),
                                    cl=self.__class__.__name__,

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1082,8 +1082,7 @@ class Project(EObject):
             return output
         else:
             return '<%s Object> %s' % (self.__class__.__name__,
-                                       self._urn
-                                       )
+                                       self._urn)
 
     def prearchive_code(self):
         """ Gets project prearchive code.
@@ -1545,8 +1544,7 @@ class Experiment(EObject):
             return output
         else:
             return '<%s Object> %s' % (self.__class__.__name__,
-                                       unquote(uri_last(self._uri))
-                                       )
+                                       unquote(uri_last(self._uri)))
 
     def shares(self, id_filter='*'):
         """ Returns the projects sharing this experiment.
@@ -1766,8 +1764,7 @@ class Resource(EObject):
             return output
         else:
             return '<%s Object> %s' % (self.__class__.__name__,
-                                       unquote(uri_last(self._uri))
-                                       )
+                                       unquote(uri_last(self._uri)))
 
     def get(self, dest_dir, extract=False):
         """ Downloads all the files within a resource.

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1046,14 +1046,15 @@ class Project(EObject):
 
     def __repr__(self):
         interface = self._intf
-        project_id = uri_last(self._uri)
 
         # Check if project exists
 
         if self.exists():
+            project_id = self.id()
+
             # Fetch data project
             if hasattr(interface, '_projectData'):
-                data = interface._projectData
+                data = interface._projectData 
             else:
                 data = interface.select('xnat:projectData').all().data
                 interface._projectData = data
@@ -1463,11 +1464,11 @@ class Subject(EObject):
 
     def __repr__(self):
         interface = self._intf
-        subject_id = uri_last(self._uri)
 
         # Check if subject exists
 
         if self.exists():
+            subject_id = self.id()
 
             # Fetch data subject
             if hasattr(interface, '_subjectData'):
@@ -1589,10 +1590,11 @@ class Experiment(EObject):
 
     def __repr__(self):
         intf = self._intf
-        eid = uri_last(self._uri)
 
         # Check if subject exists
         if self.exists():
+            eid = self.id()
+
 
             # Fetch data experiment
             if hasattr(intf, '_experimentData'):
@@ -1786,11 +1788,10 @@ class Scan(EObject):
 
     def __repr__(self):
         interface = self._intf
-        scan_id = uri_last(self._uri)
 
         # Check if subject exists
-
         if self.exists():
+            scan_id = self.id()
 
             # Fetch data scan
             attrs = ['type', 'frames', 'quality']
@@ -1834,11 +1835,11 @@ class Scan(EObject):
 class Resource(EObject):
 
     def __repr__(self):
-        resource_id = uri_last(self._uri)
 
         # Check if resource exists
 
         if self.exists():
+            resource_id = self.id()
 
             # Fetch data files
             files_count = len(self.files().fetchall())

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1565,6 +1565,28 @@ class Subject(EObject):
 @add_metaclass(ElementType)
 class Experiment(EObject):
 
+    def __init__(self, cbase, interface):
+        items = cbase.split('/')
+        e = []
+        if 'subjects' not in items \
+                and 'projects' in items and 'experiments' in items:
+            ID = uri_last(cbase)
+            e = interface.array.experiments(experiment_id=ID,
+                                            columns=['subject_id']).data
+
+        if len(e) == 1:
+            subject_id = e[0]['subject_ID']
+            project_id = e[0]['project']
+
+            cbase = '%s/projects/%s/subjects/%s/experiments/%s'
+            cbase = cbase % (interface._get_entry_point(),
+                             project_id,
+                             subject_id,
+                             ID)
+            return super(Experiment, self).__init__(cbase, interface)
+
+        return super(Experiment, self).__init__(cbase, interface)
+
     def __repr__(self):
         intf = self._intf
         eid = uri_last(self._uri)

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1772,31 +1772,25 @@ class Scan(EObject):
     def __repr__(self):
         interface = self._intf
         scan_id = uri_last(self._uri)
-        experiment_id = uri_nextlast(uri_parent(self._uri))
 
         # Check if subject exists
 
         if self.exists():
 
             # Fetch data scan
-            data = self.attrs.mget(['type', 'frames', 'quality'])
-            labels = ['Type', 'Frames', 'Quality']
+            attrs = ['type', 'frames', 'quality', 'series_description']
+            sc_type, n_frames, quality, series_desc = self.attrs.mget(attrs)
 
             # Creating the project url
             url = interface._server + self._uri
 
-            # Creating the dictionary
-            d = {'Scan': '{} {}'.format(scan_id, url), 'Experiment': experiment_id
-                 }
-            # Add metadata
-            for i, l in zip(data, labels):
-                if i != '':
-                    d[l] = i
-
             # Creating the output string to be returned
-            output = ''
-            for n, v in d.items():
-                output = output + '\n' + "{}: {}".format(n, v)
+            output = '<{cl} Object> {id} (`{type}` {n_frames} frames) {url}'
+            output = output.format(cl=self.__class__.__name__,
+                                   id=scan_id,
+                                   type=sc_type,
+                                   n_frames=n_frames,
+                                   url=url)
             return output
         else:
             return '<%s Object> %s' % (self.__class__.__name__,

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1588,6 +1588,7 @@ class Experiment(EObject):
 
             # Collecting experiment details
             project_id = data['project']
+            label = self.label()
             subject_id = data['subject_id']
             e = intf.array.experiments(experiment_id=eid,
                                        columns=['subject_label']).data[0]
@@ -1602,7 +1603,7 @@ class Experiment(EObject):
             url = intf._server + self._uri + '?format=html'
 
             # Creating the output string to be returned
-            output = '<{cl} Object> {id} (subject: {subject_id} '\
+            output = '<{cl} Object> {id} `{label}` (subject: {subject_id} '\
                      '`{subject_label}`) (project: {project}) {n_scans} '\
                      'scan{final_s1} {n_res} resource{final_s2} (created on '\
                      '{insert_date}) {url}'
@@ -1610,6 +1611,7 @@ class Experiment(EObject):
             fs = {True: 's', False: ''}
             output = output.format(cl=self.__class__.__name__,
                                    id=eid,
+                                   label=label,
                                    subject_id=subject_id,
                                    subject_label=subject_label,
                                    project=project_id,

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -63,12 +63,9 @@ def get_element_from_collection(rsc_name):
         Collection = globals()[rsc_name.title() + 's']
 
         return Collection([Element(join_uri(eobj._uri, rsc_name + 's', ID),
-                                   self._intf
-                                   )
-                           for eobj in self
-                           ],
-                          self._intf
-                          )
+                                   self._intf)
+                           for eobj in self],
+                          self._intf)
     return getter
 
 

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1605,7 +1605,8 @@ class Experiment(EObject):
 
             project_id = data['project']
             subject_id = data['subject_id']
-            subject_label = data['subject_label']
+            e = intf.array.experiments(experiment_id=eid, columns=['subject_label']).data[0]
+            subject_label = e['subject_label']
             insert_date = data['insert_date']
             n_res = len(list(self.resources()))
 

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1049,6 +1049,7 @@ class Project(EObject):
         project_id = uri_last(self._uri)
 
         # Check if project exists
+
         if self.exists():
 
             # Fetch data project
@@ -1440,6 +1441,7 @@ class Subject(EObject):
         subject_id = uri_last(self._uri)
 
         # Check if subject exists
+
         if self.exists():
 
             # Fetch data subject
@@ -1696,12 +1698,12 @@ class Scan(EObject):
         experiment_id = uri_nextlast(uri_parent(self._uri))
 
         # Check if subject exists
+
         if self.exists():
 
             # Fetch data scan
-            data = self.attrs.mget(['type', 'frames', 'quality', 'series_description',
-                                    'fieldStrength'])
-            labels = ['Type', 'Frames', 'Quality', 'Series Description', 'Field Strength']
+            data = self.attrs.mget(['type', 'frames', 'quality'])
+            labels = ['Type', 'Frames', 'Quality']
 
             # Creating the project url
             url = interface._server + self._uri
@@ -1748,6 +1750,7 @@ class Resource(EObject):
         resource_id = uri_last(self._uri)
 
         # Check if resource exists
+
         if self.exists():
 
             # Fetch data files

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1065,7 +1065,7 @@ class Project(EObject):
             n_subjects = len(list(self.subjects()))
 
             # Creating the project url
-            url = interface._server + self._uri
+            url = interface._server + self._uri + '?format=html'
 
             # Listing experiments
             exp = []
@@ -1498,7 +1498,7 @@ class Subject(EObject):
                 setattr(interface, '_subjectData', data)
 
             # Creating the project url
-            url = interface._server + self._uri
+            url = interface._server + self._uri + '?format=html'
 
             # Collecting data
             data = [e for e in data if e['subject_id'] == subject_id][0]
@@ -1599,7 +1599,7 @@ class Experiment(EObject):
             n_scans = len(list(self.scans()))
 
             # Creating the project url
-            url = intf._server + self._uri
+            url = intf._server + self._uri + '?format=html'
 
             # Creating the output string to be returned
             output = '<{cl} Object> {id} (subject: {subject_id} '\
@@ -1782,7 +1782,7 @@ class Scan(EObject):
             sc_type, n_frames, quality, series_desc = self.attrs.mget(attrs)
 
             # Creating the project url
-            url = interface._server + self._uri
+            url = interface._server + self._uri + '?format=html'
 
             # Creating the output string to be returned
             output = '<{cl} Object> {id} (`{type}` {n_frames} frames) {url}'

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1698,7 +1698,7 @@ class Scan(EObject):
         # Check if subject exists
         if self.exists():
 
-            # Fetch data experiment
+            # Fetch data scan
             data = self.attrs.mget(['type', 'frames', 'quality', 'series_description',
                                     'fieldStrength'])
             labels = ['Type', 'Frames', 'Quality', 'Series Description', 'Field Strength']

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1821,20 +1821,29 @@ class Resource(EObject):
 
     def __repr__(self):
 
-        # Check if resource exists
+        def sizeof_fmt(num, suffix='B'):
+            for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
+                if abs(num) < 1024.0:
+                    return "%3.2f %s%s" % (num, unit, suffix)
+                num /= 1024.0
+            return "%.2f %s%s" % (num, 'Y', suffix)
 
+        # Check if resource exists
         if self.exists():
             resource_id = self.id()
-
-            # Fetch data files
-            files_count = len(self.files().fetchall())
+            base_url = uri_parent(self._uri)
+            resources = self._intf._get_json(base_url)
+            res_info = [r for r in resources
+                        if r['xnat_abstractresource_id'] == resource_id][0]
+            fs = sizeof_fmt(float(res_info['file_size']))
 
             # Creating the output string to be returned
-            output = '<{cl} Object> {id} `{label}` ({fc} files)'
+            output = '<{cl} Object> {id} `{label}` ({fc} files {fs})'
             output = output.format(label=self.label(),
                                    cl=self.__class__.__name__,
                                    id=resource_id,
-                                   fc=files_count)
+                                   fc=res_info['file_count'],
+                                   fs=fs)
             return output
         else:
             return '<%s Object> %s' % (self.__class__.__name__,

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1428,6 +1428,23 @@ class Project(EObject):
         return [item['alias'] for item in data
                 if item['alias'] and item['ID'] == self._urn]
 
+    def desc(self):
+        """Returns the description for this project.
+
+        Returns
+        -------
+        Description (string) of the project.
+        """
+        intf = self._intf
+        if hasattr(intf, '_projectData'):
+            data = getattr(intf, '_projectData')
+        else:
+            data = intf.select('xnat:projectData').all().data
+            setattr(intf, '_projectData', data)
+
+        data = [e for e in data if e['id'] == self._urn][0]
+        return data['description']
+
 
 @add_metaclass(ElementType)
 class Subject(EObject):

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -35,21 +35,19 @@ import pkgutil
 import inspect
 import six
 from six import string_types, add_metaclass
-
 if six.PY2:
     from urllib import quote, unquote  # Python 2.X
 elif six.PY3:
     from urllib.parse import quote, unquote
-
     unicode = str
 
 DEBUG = False
-
 
 # metaclasses
 
 
 def get_element_from_element(rsc_name):
+
     def getter(self, ID):
         Element = globals()[rsc_name.title()]
 
@@ -59,6 +57,7 @@ def get_element_from_element(rsc_name):
 
 
 def get_element_from_collection(rsc_name):
+
     def getter(self, ID):
         Element = globals()[rsc_name.title()]
         Collection = globals()[rsc_name.title() + 's']
@@ -70,11 +69,11 @@ def get_element_from_collection(rsc_name):
                            ],
                           self._intf
                           )
-
     return getter
 
 
 def get_collection_from_element(rsc_name):
+
     def getter(self, id_filter='*'):
         Collection = globals()[rsc_name.title()]
         return Collection(join_uri(self._uri, rsc_name),
@@ -85,6 +84,7 @@ def get_collection_from_element(rsc_name):
 
 
 def get_collection_from_collection(rsc_name):
+
     def getter(self, id_filter='*'):
         Collection = globals()[rsc_name.title()]
 
@@ -96,6 +96,7 @@ def get_collection_from_collection(rsc_name):
 
 class ElementType(type):
     def __new__(cls, name, bases, dct):
+
         rsc_name = name.lower() + 's' \
             if name.lower() in schema.resources_singular \
             else name.lower()
@@ -154,7 +155,6 @@ def __find_all_functions__(m):
 class EObject(object):
     """ Generic Object for an element URI.
     """
-
     def __init__(self, uri, interface):
         """
             Parameters
@@ -178,9 +178,9 @@ class EObject(object):
         for m, mod_functions in functions.items():
             is_resource = False
             if (hasattr(m, 'XNAT_RESOURCE_NAME') and
-                self._urn == m.XNAT_RESOURCE_NAME) or \
+                    self._urn == m.XNAT_RESOURCE_NAME) or \
                     (hasattr(m, 'XNAT_RESOURCE_NAMES') and
-                     self._urn in m.XNAT_RESOURCE_NAMES):
+                        self._urn in m.XNAT_RESOURCE_NAMES):
                 is_resource = True
 
             if is_resource:
@@ -191,7 +191,7 @@ class EObject(object):
         return {
             'uri': self._uri,
             'interface': self._intf
-        }
+            }
 
     def __setstate__(self, dict):
         self.__init__(dict['uri'], dict['interface'])
@@ -224,18 +224,19 @@ class EObject(object):
             if fnmatch(uri_segment(
                     self._uri.split(
                         self._intf._get_entry_point(), 1)[1], -2), pattern):
+
                 reg_pat = self._intf._struct[pattern]
                 filters.setdefault('xsiType', set()).add(reg_pat)
 
         if filters:
             get_id += '&' + \
-              '&'.join('%s=%s' % (item[0], item[1])
-                       if isinstance(item[1], string_types)
-                       else '%s=%s' % (item[0],
-                                       ','.join([val for val in item[1]])
-                                       )
-                       for item in filters.items()
-                       )
+                '&'.join('%s=%s' % (item[0], item[1])
+                         if isinstance(item[1], string_types)
+                         else '%s=%s' % (item[0],
+                                         ','.join([val for val in item[1]])
+                                         )
+                         for item in filters.items()
+                         )
 
         for res in self._intf._get_json(get_id):
             if self._urn in [res.get(id_head), res.get(lbl_head)]:
@@ -2170,12 +2171,12 @@ class File(EObject):
                 # path = src
                 # name = op.basename(path).split('?')[0]
             # else:
-            # path = self._uri.split('/')[-1]
-            # name = path
-        except Exception:
-            pass  # FIXME
                 # path = self._uri.split('/')[-1]
                 # name = path
+        except Exception:
+            pass  # FIXME
+            # path = self._uri.split('/')[-1]
+            # name = path
 
         self._absuri = unquote(
             re.sub('resources/.*?/',
@@ -2216,7 +2217,7 @@ class File(EObject):
 
         # default error handling.
         if (response is not None and not response.ok) or \
-            is_xnat_error(response.content):
+           is_xnat_error(response.content):
             if DEBUG:
                 print(response.keys())
                 print(response.get("status"))

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1825,15 +1825,14 @@ class Resource(EObject):
         if self.exists():
 
             # Fetch data files
-            files_counter = len(self.files().fetchall())
+            files_count = len(self.files().fetchall())
 
-            # Creating the dictionary
-            d = {'Resource': resource_id, 'Files': files_counter
-                 }
             # Creating the output string to be returned
-            output = ''
-            for n, v in d.items():
-                output = output + '\n' + "{}: {}".format(n, v)
+            output = '<{cl} Object> {id} `{label}` ({fc} files)'
+            output = output.format(label=self.label(),
+                                   cl=self.__class__.__name__,
+                                   id=resource_id,
+                                   fc=files_count)
             return output
         else:
             return '<%s Object> %s' % (self.__class__.__name__,

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -33,9 +33,6 @@ from . import derivatives
 import types
 import pkgutil
 import inspect
-import json
-from IPython import get_ipython
-from IPython.display import display, HTML
 import six
 from six import string_types, add_metaclass
 
@@ -232,13 +229,13 @@ class EObject(object):
 
         if filters:
             get_id += '&' + \
-                      '&'.join('%s=%s' % (item[0], item[1])
-                               if isinstance(item[1], string_types)
-                               else '%s=%s' % (item[0],
-                                               ','.join([val for val in item[1]])
-                                               )
-                               for item in filters.items()
-                               )
+              '&'.join('%s=%s' % (item[0], item[1])
+                       if isinstance(item[1], string_types)
+                       else '%s=%s' % (item[0],
+                                       ','.join([val for val in item[1]])
+                                       )
+                       for item in filters.items()
+                       )
 
         for res in self._intf._get_json(get_id):
             if self._urn in [res.get(id_head), res.get(lbl_head)]:
@@ -374,8 +371,8 @@ class EObject(object):
         if datatype is None:
             for uri_pattern in struct.keys():
                 if fnmatch(
-                        self._uri.split(
-                            self._intf._get_entry_point(), 1)[1], uri_pattern):
+                    self._uri.split(
+                        self._intf._get_entry_point(), 1)[1], uri_pattern):
                     datatype = struct.get(uri_pattern)
                     break
             else:
@@ -388,7 +385,7 @@ class EObject(object):
             local_params = \
                 [param for param in params
                  if param not in schema.resources_types + ['use_label']
-                 and (param.startswith(datatype) or '/' not in param)
+                    and (param.startswith(datatype) or '/' not in param)
                  ]
 
             create_uri = '%s?xsiType=%s' % (self._uri, datatype)
@@ -396,6 +393,7 @@ class EObject(object):
             if 'ID' not in local_params \
                     and '%s/ID' % datatype not in local_params \
                     and params.get('use_label'):
+
                 create_uri += '&%s/ID=%s' % (datatype, uri_last(self._uri))
 
             if local_params:
@@ -569,7 +567,6 @@ class CObject(object):
             >>> for subject in interface.select.projects().subjects():
             >>>     print subject
     """
-
     def __init__(self, cbase, interface, pattern='*', nested=None,
                  id_header='ID', columns=[], filters={}):
 
@@ -648,7 +645,7 @@ class CObject(object):
                     else '%s=%s' % (
                         item[0], ','.join([val for val in item[1]]))
                     for item in self._filters.items()
-                )
+                    )
 
             if DEBUG:
                 print(uri + query_string)
@@ -851,7 +848,7 @@ class CObject(object):
         if isinstance(k, slice):
             return islice(self, k.start, k.stop, k.step)
         else:
-            return next(islice(self, k, k + 1))
+            return next(islice(self, k, k+1))
 
     def get(self, *args):
         """ Returns every element.
@@ -994,7 +991,7 @@ class CObject(object):
             return_values=['xnat:subjectData/PROJECT',
                            'xnat:subjectData/SUBJECT_ID'],
             _filter=constraints
-        )
+            )
 
         searchpop = ['%s/projects/' % self._intf._get_entry_point() +
                      '%(project)s/subjects/%(subject_id)s' % res
@@ -1027,7 +1024,6 @@ class CObject(object):
         cobj._id_header = backup_header
 
         return self
-
 
 # specialized classes
 
@@ -1257,8 +1253,8 @@ class Project(EObject):
             # re-select with the ID of the matching experiment.
             return Experiment(datapath % (
                 self._intf._get_entry_point(), self.id(), tmp.id()),
-                              self._intf
-                              )
+                self._intf
+                )
 
     def last_modified(self):
         """ Gets the last modified dates for all the project subjects.
@@ -1305,7 +1301,7 @@ class Project(EObject):
             except IndexError:
                 raise ValueError(
                     'Protocol %s not in current schema' % protocol
-                )
+                    )
 
             try:
                 definitions_element = protocol_element.xpath(
@@ -1315,7 +1311,7 @@ class Project(EObject):
                 definitions_element = lxml.etree.Element(
                     lxml.etree.QName(tree.nsmap['xnat'], 'definitions'),
                     nsmap=tree.nsmap
-                )
+                    )
                 protocol_element.append(definitions_element)
 
             for group, fields in value.items():
@@ -1334,7 +1330,7 @@ class Project(EObject):
                     group_element = lxml.etree.Element(
                         lxml.etree.QName(tree.nsmap['xnat'], 'definition'),
                         nsmap=tree.nsmap
-                    )
+                        )
                     group_element.set('ID', group)
                     group_element.set(
                         'data-type', protocol_element.get('data-type'))
@@ -1344,7 +1340,7 @@ class Project(EObject):
                     fields_element = lxml.etree.Element(
                         lxml.etree.QName(tree.nsmap['xnat'], 'fields'),
                         nsmap=tree.nsmap
-                    )
+                        )
                     group_element.append(fields_element)
 
                 for field, datatype in fields.items():
@@ -1365,7 +1361,7 @@ class Project(EObject):
                             "xnat:%s/fields/field[name=%s]/field" % (
                                 protocol_element.get(
                                     'data-type').split(':')[-1], field)
-                        )
+                            )
                         fields_element.append(field_element)
                         update = True
         if update:
@@ -1374,7 +1370,7 @@ class Project(EObject):
                 'text/xml',
                 'cust.xml',
                 'cust.xml'
-            )
+                )
 
             uri = self._uri
             if allow_data_deletion:
@@ -1835,7 +1831,7 @@ class Resource(EObject):
                 dest_dir,
                 uri_last(self._uri),
                 member.split('files', 1)[1].split(os.sep, 1)[1]
-            )
+                )
 
             if not op.exists(op.dirname(new_path)):
                 os.makedirs(op.dirname(new_path))
@@ -2178,13 +2174,13 @@ class File(EObject):
             # name = path
         except Exception:
             pass  # FIXME
-            # path = self._uri.split('/')[-1]
-            # name = path
+                # path = self._uri.split('/')[-1]
+                # name = path
 
         self._absuri = unquote(
             re.sub('resources/.*?/',
                    'resources/%s/' % resource_id, self._uri)
-        )
+            )
 
         query_args = {
             'format': format,
@@ -2192,7 +2188,7 @@ class File(EObject):
             'tags': tags,
             'overwrite': 'true' if overwrite else 'false',
             'inbody': 'true'
-        }
+            }
 
         if 'params' in datatypes:
             query_args.update(datatypes['params'])
@@ -2220,7 +2216,7 @@ class File(EObject):
 
         # default error handling.
         if (response is not None and not response.ok) or \
-                is_xnat_error(response.content):
+            is_xnat_error(response.content):
             if DEBUG:
                 print(response.keys())
                 print(response.get("status"))
@@ -2414,7 +2410,6 @@ class In_Files(Files):
 class Out_Files(Files):
     pass
 
-
 # Utility functions for downloading and extracting zip archives
 
 
@@ -2432,6 +2427,7 @@ def _datatypes_from_query(query):
 
 def query_with(interface, join_field,
                common_field, return_values, _filter):
+
     _stm = (join_field.split('/')[0], return_values)
     _cls = rewrite_query(interface, join_field,
                          common_field, _filter)
@@ -2441,6 +2437,7 @@ def query_with(interface, join_field,
 
 def rewrite_query(interface, join_field,
                   common_field, _filter):
+
     _new_filter = []
 
     for _f in _filter:
@@ -2452,7 +2449,7 @@ def rewrite_query(interface, join_field,
             _datatype = _f[0].split('/')[0]
             _res = interface.select(
                 _datatype, ['%s/%s' % (_datatype, common_field)]
-            ).where([_f, 'AND'])
+                ).where([_f, 'AND'])
 
             _new_f = [(join_field, '=', '%s' % sid)
                       for sid in _res['subject_id']

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1046,17 +1046,17 @@ class Project(EObject):
 
     def __repr__(self):
         interface = self._intf
-        project_id = uri_last(self._uri)
+        project_id = self.id()
 
         # Check if project exists
 
         if self.exists():
             # Fetch data project
             if hasattr(interface, '_projectData'):
-                data = getattr(interface, '_projectData')
+                data = interface._projectData 
             else:
                 data = interface.select('xnat:projectData').all().data
-                setattr(interface, '_projectData', data)
+                interface._projectData = data
 
             data = [e for e in data if e['id'] == project_id][0]
             name = data['name']
@@ -1452,15 +1452,7 @@ class Project(EObject):
         -------
         Description (string) of the project.
         """
-        intf = self._intf
-        if hasattr(intf, '_projectData'):
-            data = getattr(intf, '_projectData')
-        else:
-            data = intf.select('xnat:projectData').all().data
-            setattr(intf, '_projectData', data)
-
-        data = [e for e in data if e['id'] == self._urn][0]
-        return data['description']
+        return self.attrs.get('description')
 
 
 @add_metaclass(ElementType)
@@ -1471,7 +1463,7 @@ class Subject(EObject):
 
     def __repr__(self):
         interface = self._intf
-        subject_id = uri_last(self._uri)
+        subject_id = self.id()
 
         # Check if subject exists
 
@@ -1479,7 +1471,7 @@ class Subject(EObject):
 
             # Fetch data subject
             if hasattr(interface, '_subjectData'):
-                data = getattr(interface, '_subjectData')
+                data = interface._subjectData
             else:
                 columns = ['xnat:subjectData/PROJECT',
                            'xnat:subjectData/SUBJECT_ID',
@@ -1495,7 +1487,7 @@ class Subject(EObject):
 
                 dt = 'xnat:subjectData'
                 data = interface.select(dt, columns=columns).all().data
-                setattr(interface, '_subjectData', data)
+                interface._subjectData = data
 
             # Creating the project url
             url = interface._server + self._uri + '?format=html'
@@ -1575,19 +1567,19 @@ class Experiment(EObject):
 
     def __repr__(self):
         intf = self._intf
-        eid = uri_last(self._uri)
+        eid = self.id()
 
         # Check if subject exists
         if self.exists():
 
             # Fetch data experiment
             if hasattr(intf, '_experimentData'):
-                data = getattr(intf, '_experimentData')
+                data = intf._experimentData
             else:
                 e = intf.array.experiments(experiment_id=eid).data[0]
                 filter = [('{}/{}'.format(e['xsiType'], 'ID'), '=', eid)]
                 data = intf.select(e['xsiType']).where(filter).data[0]
-                setattr(intf, '_experimentData', data)
+                intf._experimentData = data
 
             project_id = data['project']
             subject_id = data['subject_id']
@@ -1771,25 +1763,26 @@ class Scan(EObject):
 
     def __repr__(self):
         interface = self._intf
-        scan_id = uri_last(self._uri)
+        scan_id = self.id()
 
         # Check if subject exists
 
         if self.exists():
 
             # Fetch data scan
-            attrs = ['type', 'frames', 'quality', 'series_description']
-            sc_type, n_frames, quality, series_desc = self.attrs.mget(attrs)
+            attrs = ['type', 'frames', 'quality']
+            sc_type, n_frames, quality = self.attrs.mget(attrs)
 
             # Creating the project url
             url = interface._server + self._uri + '?format=html'
 
             # Creating the output string to be returned
-            output = '<{cl} Object> {id} (`{type}` {n_frames} frames) {url}'
+            output = '<{cl} Object> {id} (`{type}` {n_frames} frames) {quality} {url}'
             output = output.format(cl=self.__class__.__name__,
                                    id=scan_id,
                                    type=sc_type,
                                    n_frames=n_frames,
+                                   quality=quality,
                                    url=url)
             return output
         else:
@@ -1818,7 +1811,7 @@ class Scan(EObject):
 class Resource(EObject):
 
     def __repr__(self):
-        resource_id = uri_last(self._uri)
+        resource_id = self.id()
 
         # Check if resource exists
 

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1549,8 +1549,7 @@ class Experiment(EObject):
         if 'subjects' not in items \
                 and 'projects' in items and 'experiments' in items:
             ID = uri_last(cbase)
-            e = interface.array.experiments(experiment_id=ID,
-                                            columns=['subject_id']).data
+            e = interface.array.experiments(experiment_id=ID).data
 
         if len(e) == 1:
             subject_id = e[0]['subject_ID']
@@ -1767,8 +1766,11 @@ class Scan(EObject):
             scan_id = self.id()
 
             # Collect scan details
-            attrs = ['type', 'frames', 'quality']
-            sc_type, n_frames, quality = self.attrs.mget(attrs)
+            attrs = ['ID', 'type', 'frames', 'quality']
+            base_url = uri_parent(self._uri)
+            scans = self._intf._get_json('{}?columns={}'.format(base_url,
+                                                                ','.join(attrs)))
+            scan_info = [r for r in scans if r['ID'] == scan_id][0]
 
             url = interface._server + self._uri + '?format=html'
 
@@ -1776,9 +1778,9 @@ class Scan(EObject):
             output = '<{cl} Object> {id} (`{type}` {n_frames} frames) {quality} {url}'
             output = output.format(cl=self.__class__.__name__,
                                    id=scan_id,
-                                   type=sc_type,
-                                   n_frames=n_frames,
-                                   quality=quality,
+                                   type=scan_info['type'],
+                                   n_frames=scan_info['frames'],
+                                   quality=scan_info['quality'],
                                    url=url)
             return output
         else:

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -188,18 +188,15 @@ class EObject(object):
                     setattr(self, f.__name__, types.MethodType(f, self))
 
     def __getstate__(self):
-        return {
-            'uri': self._uri,
-            'interface': self._intf
-            }
+        return {'uri': self._uri,
+                'interface': self._intf}
 
     def __setstate__(self, dict):
         self.__init__(dict['uri'], dict['interface'])
 
     def __repr__(self):
         return '<%s Object> %s' % (self.__class__.__name__,
-                                   unquote(uri_last(self._uri))
-                                   )
+                                   unquote(uri_last(self._uri)))
 
     def _getcell(self, col):
         """ Gets a single property of the element resource.
@@ -216,8 +213,7 @@ class EObject(object):
 
         columns = set([col for col in cols
                        if col not in schema.json[self._urt]
-                       or col != 'URI'] + schema.json[self._urt]
-                      )
+                       or col != 'URI'] + schema.json[self._urt])
         get_id = p_uri + '?format=json&columns=%s' % ','.join(columns)
 
         for pattern in self._intf._struct.keys():
@@ -233,10 +229,8 @@ class EObject(object):
                 '&'.join('%s=%s' % (item[0], item[1])
                          if isinstance(item[1], string_types)
                          else '%s=%s' % (item[0],
-                                         ','.join([val for val in item[1]])
-                                         )
-                         for item in filters.items()
-                         )
+                                         ','.join([val for val in item[1]]))
+                         for item in filters.items())
 
         for res in self._intf._get_json(get_id):
             if self._urn in [res.get(id_head), res.get(lbl_head)]:
@@ -2122,8 +2116,7 @@ class File(EObject):
 
     def __repr__(self):
         return '<%s Object> %s' % (self.__class__.__name__,
-                                   self._urn
-                                   )
+                                   self._urn)
 
     def attributes(self):
         """ Files attributes include:
@@ -2397,10 +2390,8 @@ class Experiments(CObject):
 
     def sharing(self, projects=[]):
         return Experiments([eobj for eobj in self
-                            if set(projects).issubset(eobj.shares().get())
-                            ],
-                           self._intf
-                           )
+                            if set(projects).issubset(eobj.shares().get())],
+                           self._intf)
 
     def share(self, project):
         for eobj in self:

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1046,14 +1046,14 @@ class Project(EObject):
 
     def __repr__(self):
         interface = self._intf
-        project_id = self.id()
+        project_id = uri_last(self._uri)
 
         # Check if project exists
 
         if self.exists():
             # Fetch data project
             if hasattr(interface, '_projectData'):
-                data = interface._projectData 
+                data = interface._projectData
             else:
                 data = interface.select('xnat:projectData').all().data
                 interface._projectData = data
@@ -1463,7 +1463,7 @@ class Subject(EObject):
 
     def __repr__(self):
         interface = self._intf
-        subject_id = self.id()
+        subject_id = uri_last(self._uri)
 
         # Check if subject exists
 
@@ -1567,7 +1567,7 @@ class Experiment(EObject):
 
     def __repr__(self):
         intf = self._intf
-        eid = self.id()
+        eid = uri_last(self._uri)
 
         # Check if subject exists
         if self.exists():
@@ -1763,7 +1763,7 @@ class Scan(EObject):
 
     def __repr__(self):
         interface = self._intf
-        scan_id = self.id()
+        scan_id = uri_last(self._uri)
 
         # Check if subject exists
 
@@ -1811,7 +1811,7 @@ class Scan(EObject):
 class Resource(EObject):
 
     def __repr__(self):
-        resource_id = self.id()
+        resource_id = uri_last(self._uri)
 
         # Check if resource exists
 

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1048,18 +1048,13 @@ class Project(EObject):
         interface = self._intf
 
         # Check if project exists
-
         if self.exists():
             project_id = self.id()
 
-            # Fetch data project
-            if hasattr(interface, '_projectData'):
-                data = interface._projectData 
-            else:
-                data = interface.select('xnat:projectData').all().data
-                interface._projectData = data
-
+            data = interface.select('xnat:projectData').all().data
             data = [e for e in data if e['id'] == project_id][0]
+
+            # Collecting projects details
             name = data['name']
 
             # Fetch data subjects
@@ -1466,35 +1461,27 @@ class Subject(EObject):
         interface = self._intf
 
         # Check if subject exists
-
         if self.exists():
             subject_id = self.id()
+            columns = ['xnat:subjectData/PROJECT',
+                       'xnat:subjectData/SUBJECT_ID',
+                       'xnat:subjectData/INSERT_DATE',
+                       'xnat:subjectData/INSERT_USER',
+                       'xnat:subjectData/GENDER_TEXT',
+                       'xnat:subjectData/HANDEDNESS_TEXT',
+                       'xnat:subjectData/SES',
+                       'xnat:subjectData/ADD_IDS',
+                       'xnat:subjectData/RACE',
+                       'xnat:subjectData/ETHNICITY',
+                       'xnat:subjectData/SUBJECT_LABEL']
 
-            # Fetch data subject
-            if hasattr(interface, '_subjectData'):
-                data = interface._subjectData
-            else:
-                columns = ['xnat:subjectData/PROJECT',
-                           'xnat:subjectData/SUBJECT_ID',
-                           'xnat:subjectData/INSERT_DATE',
-                           'xnat:subjectData/INSERT_USER',
-                           'xnat:subjectData/GENDER_TEXT',
-                           'xnat:subjectData/HANDEDNESS_TEXT',
-                           'xnat:subjectData/SES',
-                           'xnat:subjectData/ADD_IDS',
-                           'xnat:subjectData/RACE',
-                           'xnat:subjectData/ETHNICITY',
-                           'xnat:subjectData/SUBJECT_LABEL']
-
-                dt = 'xnat:subjectData'
-                data = interface.select(dt, columns=columns).all().data
-                interface._subjectData = data
-
-            # Creating the project url
-            url = interface._server + self._uri + '?format=html'
-
-            # Collecting data
+            dt = 'xnat:subjectData'
+            data = interface.select(dt, columns=columns).all().data
+            interface._subjectData = data
             data = [e for e in data if e['subject_id'] == subject_id][0]
+
+            # Collecting subject details
+            url = interface._server + self._uri + '?format=html'
 
             project_id = data['project']
             age = self.attrs.get('age')
@@ -1591,23 +1578,19 @@ class Experiment(EObject):
     def __repr__(self):
         intf = self._intf
 
-        # Check if subject exists
+        # Check if experiment exists
         if self.exists():
             eid = self.id()
 
+            e = intf.array.experiments(experiment_id=eid).data[0]
+            filter = [('{}/{}'.format(e['xsiType'], 'ID'), '=', eid)]
+            data = intf.select(e['xsiType']).where(filter).data[0]
 
-            # Fetch data experiment
-            if hasattr(intf, '_experimentData'):
-                data = intf._experimentData
-            else:
-                e = intf.array.experiments(experiment_id=eid).data[0]
-                filter = [('{}/{}'.format(e['xsiType'], 'ID'), '=', eid)]
-                data = intf.select(e['xsiType']).where(filter).data[0]
-                intf._experimentData = data
-
+            # Collecting experiment details
             project_id = data['project']
             subject_id = data['subject_id']
-            e = intf.array.experiments(experiment_id=eid, columns=['subject_label']).data[0]
+            e = intf.array.experiments(experiment_id=eid,
+                                       columns=['subject_label']).data[0]
             subject_label = e['subject_label']
             insert_date = data['insert_date']
             n_res = len(list(self.resources()))
@@ -2386,10 +2369,8 @@ class Subjects(CObject):
 
     def sharing(self, projects=[]):
         return Subjects([eobj for eobj in self
-                         if set(projects).issubset(eobj.shares().get())
-                         ],
-                        self._intf
-                        )
+                         if set(projects).issubset(eobj.shares().get())],
+                        self._intf)
 
     def share(self, project):
         for eobj in self:

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1445,7 +1445,7 @@ class Project(EObject):
         return [item['alias'] for item in data
                 if item['alias'] and item['ID'] == self._urn]
 
-    def desc(self):
+    def description(self):
         """Returns the description for this project.
 
         Returns

--- a/pyxnat/core/schema.py
+++ b/pyxnat/core/schema.py
@@ -125,9 +125,8 @@ def datatypes(root):
 
     return [element.get('type')
             for element in root.xpath('/xs:schema/xs:element',
-                                      namespaces=nsmap)
-            ]
-
+                                      namespaces=nsmap)]
+                                      
 
 def get_nsmap(node):
     nsmap = node.nsmap

--- a/pyxnat/core/search.py
+++ b/pyxnat/core/search.py
@@ -6,6 +6,9 @@ except ImportError:
     from io import StringIO
 try:
     unicode
+    import sys
+    reload(sys)  # Reload does the trick!
+    sys.setdefaultencoding('UTF8')
 except NameError:
     unicode = str
 from six import string_types

--- a/pyxnat/tests/array_test.py
+++ b/pyxnat/tests/array_test.py
@@ -62,7 +62,7 @@ class ArrayTests(unittest.TestCase):
     @skip_if_no_network
     def test_search_experiments(self):
         et = 'xnat:subjectData'
-        e = self._intf.array.search_experiments(project_id='nosetests3',
+        e = self._intf.array.search_experiments(project_id='nosetests5',
                                                 experiment_type=et)
         res = e.data
         self.assertGreaterEqual(len(res), 1)

--- a/pyxnat/tests/attributes_test.py
+++ b/pyxnat/tests/attributes_test.py
@@ -15,7 +15,7 @@ interfaces.STUBBORN = True
 sid = uuid1().hex
 eid = uuid1().hex
 
-subject = central.select.project('nosetests3').subject(sid)
+subject = central.select.project('nosetests5').subject(sid)
 experiment = subject.experiment(eid)
 
 

--- a/pyxnat/tests/custom_variables_test.py
+++ b/pyxnat/tests/custom_variables_test.py
@@ -7,7 +7,7 @@ from . import skip_if_no_network
 
 fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 central = Interface(config=fp)
-project = central.select.project('nosetests3')
+project = central.select.project('nosetests5')
 
 variables = {'Subjects': {'newgroup': {'foo': 'string', 'bar': 'int'}}}
 

--- a/pyxnat/tests/pipelines_test.py
+++ b/pyxnat/tests/pipelines_test.py
@@ -8,5 +8,5 @@ central = Interface(config=fp)
 
 def test_pipelines_get():
     from pyxnat.core import pipelines
-    p = pipelines.Pipelines('nosetests3', central)
+    p = pipelines.Pipelines('nosetests5', central)
     print(p.get())

--- a/pyxnat/tests/provenance_test.py
+++ b/pyxnat/tests/provenance_test.py
@@ -6,7 +6,7 @@ import os.path as op
 
 fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 central = Interface(config=fp)
-project = central.select.project('nosetests3')
+project = central.select.project('nosetests5')
 
 prov = {
     'program': 'young',

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -133,8 +133,8 @@ def test_resource_not_exists():
 @skip_if_no_network
 def test_info_resource():
     assert isinstance(resource_1, object)
-    expected_output = '<Resource Object> obscure_algorithm_output '\
-        '`obscure_algorithm_output` (66 files)'
+    expected_output = '<Resource Object> 123221564 '\
+        '`obscure_algorithm_output` (66 files 2.06 GB)'
     assert list(sorted(str(resource_1))) == list(sorted(expected_output))
 
 

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -110,7 +110,7 @@ def test_scan_not_exists():
 @skip_if_no_network
 def test_info_scan():
     assert isinstance(scan_1, object)
-    expected_output = '<Scan Object> 11 (`SPGR` 175 frames) '\
+    expected_output = '<Scan Object> 11 (`SPGR` 175 frames)  '\
         'https://central.xnat.org/data/projects/surfmask_smpl/subjects/'\
         'CENTRAL_S01791/experiments/CENTRAL_E04850/scans/11?format=html'
     assert list(sorted(str(scan_1))) == list(sorted(expected_output))

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -84,11 +84,11 @@ def test_experiment_not_exists():
 @skip_if_no_network
 def test_info_experiment():
     assert isinstance(exp_1, object)
-    expected_output = '\n' + 'Session: CENTRAL_E04850 https://central.xnat.org/data/projects/surfmask_smpl/subjects/' \
-                             'CENTRAL_S01791/experiments/CENTRAL_E04850' \
-                      + '\n' + 'Subject: CENTRAL_S01791' + '\n' + 'Project: surfmask_smpl' + '\n' + 'Scans: 4' \
-                      + '\n' + 'Insert user: mmilch' + '\n' + 'Insert date: 2012-04-10 17:27:25.0' \
-                      + '\n' + 'Date: 2008-05-06' + '\n' + 'Type: IGT_FMRI_NEURO'
+    expected_output = '<Experiment Object> CENTRAL_E04850 (subject: '\
+        'CENTRAL_S01791 `001`) (project: surfmask_smpl) 4 scans 1 resource '\
+        '(created on 2012-04-10 17:27:25.0) https://central.xnat.org/'\
+        'data/projects/surfmask_smpl/subjects/CENTRAL_S01791/experiments/'\
+        'CENTRAL_E04850'
     assert list(sorted(str(exp_1))) == list(sorted(expected_output))
 
 

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -4,8 +4,9 @@ from . import skip_if_no_network
 
 _modulepath = op.dirname(op.abspath(__file__))
 
-central = Interface(config=op.join(op.dirname(op.abspath(__file__)),
-                                   'central.cfg'))
+fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+print(fp)
+central = Interface(config=fp)
 
 proj_1 = central.select.project('surfmask_smpl')
 subj_1 = proj_1.subject('CENTRAL_S01791')
@@ -40,7 +41,7 @@ def test_info_project():
     expected_output = '<Project Object> surfmask_smpl `Surface masking '\
         'samples` (public) 43 subjects 43 MR experiments (owner: mmilch) '\
         '(created on 2012-04-05 15:45:30.0) https://central.xnat.org/data/'\
-        'projects/surfmask_smpl'
+        'projects/surfmask_smpl?format=html'
     assert list(sorted(str(proj_1))) == list(sorted(expected_output))
 
 
@@ -63,7 +64,7 @@ def test_info_subject():
     assert isinstance(subj_1, object)
     expected_output = '<Subject Object> CENTRAL_S01791 `001` (project: '\
         'surfmask_smpl) (Gender: U) 1 experiment https://central.xnat.org/'\
-        'data/projects/surfmask_smpl/subjects/CENTRAL_S01791'
+        'data/projects/surfmask_smpl/subjects/CENTRAL_S01791?format=html'
     assert list(sorted(str(subj_1))) == list(sorted(expected_output))
 
 
@@ -88,7 +89,7 @@ def test_info_experiment():
         'CENTRAL_S01791 `001`) (project: surfmask_smpl) 4 scans 1 resource '\
         '(created on 2012-04-10 17:27:25.0) https://central.xnat.org/'\
         'data/projects/surfmask_smpl/subjects/CENTRAL_S01791/experiments/'\
-        'CENTRAL_E04850'
+        'CENTRAL_E04850?format=html'
     assert list(sorted(str(exp_1))) == list(sorted(expected_output))
 
 
@@ -111,7 +112,7 @@ def test_info_scan():
     assert isinstance(scan_1, object)
     expected_output = '<Scan Object> 11 (`SPGR` 175 frames) '\
         'https://central.xnat.org/data/projects/surfmask_smpl/subjects/'\
-        'CENTRAL_S01791/experiments/CENTRAL_E04850/scans/11'
+        'CENTRAL_S01791/experiments/CENTRAL_E04850/scans/11?format=html'
     assert list(sorted(str(scan_1))) == list(sorted(expected_output))
 
 

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -1,18 +1,17 @@
 from pyxnat import Interface
 import os.path as op
 from . import skip_if_no_network
-from IPython import get_ipython
 
 _modulepath = op.dirname(op.abspath(__file__))
 
 central = Interface(config=op.join(op.dirname(op.abspath(__file__)),
                                    'central.cfg'))
 
-proj_1 = central.select.project('CENTRAL_OASIS_CS')
-subj_1 = proj_1.subject('OAS1_0002')
-exp_1 = subj_1.experiments('OAS1_0002_MR1')
-scan_1 = exp_1.scan('mpr-1')
-resource_1 = scan_1.resource('')
+proj_1 = central.select.project('surfmask_smpl')
+subj_1 = proj_1.subject('CENTRAL_S01791')
+exp_1 = subj_1.experiment('CENTRAL_E04850')
+scan_1 = exp_1.scan('11')
+resource_1 = exp_1.resource('obscure_algorithm_output')
 
 proj_2 = central.select.project('NFB')
 subj_2 = proj_2.subject('BOA')
@@ -38,17 +37,13 @@ def test_project_not_exists():
 @skip_if_no_network
 def test_info_project():
     assert isinstance(proj_1, object)
-    expected_output_ipython = 'Project: surfmask_smpl(Surface masking samples) ' \
-                              'https://central.xnat.org/data/projects/surfmask_smpl ' \
-                              'Subjects: 43' \
-                              'Description: The collection of structural T1 MRI scans from &quot;Functional Data for ' \
-                              'Neurosurgical Planning&quot; (IGT_FMRI_NEURO) project processed with surface obscuring ' \
-                              'a' \
-                              'Project owners:  mmilch' \
-                              'Insert date: 2012-04-05 15:45:30.0' \
-                              'Access: public' \
-                              'MR experiments: 43'
-    assert str(proj_1) == str(expected_output_ipython)
+    expected_output = '\n' + 'Project: surfmask_smpl(Surface masking samples) \
+    https://central.xnat.org/data/projects/surfmask_smpl' + '\n' + 'Subjects: 43' \
+                      + '\n' + 'Description: The collection of structural T1 MRI scans from &quot;Functional \
+    Data for Neurosurgical Planning&quot; (IGT_FMRI_NEURO) project processed with surface \
+    obscuring algorithm.' + '\n' + 'Project owners:  mmilch ' + '\n' + \
+                      'Insert date: 2012-04-05 15:45:30.0' + '\n' + 'Access: public' + '\n' + 'MR experiments: 43'
+    assert list(sorted(str(proj_1))) == list(sorted(expected_output))
 
 
 @skip_if_no_network
@@ -68,13 +63,11 @@ def test_subject_not_exists():
 @skip_if_no_network
 def test_info_subject():
     assert isinstance(subj_1, object)
-    expected_output_ipython = 'Subject: CENTRAL_S01791 https://central.xnat.org/data/projects/surfmask_smpl/subjects' \
-                              '/CENTRAL_S01791' \ 
-                              'Project: surfmask_smpl' \
-                              'Insert user: mmilch' \
-                              'Insert date: 2012-04-10 17:27:22.0' \
-                              'Gender: U'
-    assert str(subj_1) == str(expected_output_ipython)
+    expected_output = '\n' + 'Subject: CENTRAL_S01791 https://central.xnat.org/data/projects/surfmask_smpl/subjects/' \
+                             'CENTRAL_S01791' \
+                      + '\n' + 'Project: surfmask_smpl' + '\n' + 'Insert user: mmilch' \
+                      + '\n' + 'Insert date: 2012-04-10 17:27:22.0' + '\n' + 'Gender: U'
+    assert list(sorted(str(subj_1))) == list(sorted(expected_output))
 
 
 @skip_if_no_network
@@ -94,15 +87,12 @@ def test_experiment_not_exists():
 @skip_if_no_network
 def test_info_experiment():
     assert isinstance(exp_1, object)
-    expected_output_ipython = 'Session: CENTRAL_E04850 https://central.xnat.org/data/experiments/CENTRAL_E04850' \
-                              'Subject: CENTRAL_S01791' \
-                              'Project: surfmask_smpl' \
-                              'Scans: 4' \
-                              'Insert user: mmilch' \
-                              'Insert date:  2012-04-10 17:27:25.0' \
-                              'Date: 2008-05-06' \
-                              'Type: IGT_FMRI_NEURO'
-    assert str(exp_1) == str(expected_output_ipython)
+    expected_output = '\n' + 'Session: CENTRAL_E04850 https://central.xnat.org/data/projects/surfmask_smpl/subjects/' \
+                             'CENTRAL_S01791/experiments/CENTRAL_E04850' \
+                      + '\n' + 'Subject: CENTRAL_S01791' + '\n' + 'Project: surfmask_smpl' + '\n' + 'Scans: 4' \
+                      + '\n' + 'Insert user: mmilch' + '\n' + 'Insert date: 2012-04-10 17:27:25.0' \
+                      + '\n' + 'Date: 2008-05-06' + '\n' + 'Type: IGT_FMRI_NEURO'
+    assert list(sorted(str(exp_1))) == list(sorted(expected_output))
 
 
 @skip_if_no_network
@@ -122,13 +112,11 @@ def test_scan_not_exists():
 @skip_if_no_network
 def test_info_scan():
     assert isinstance(scan_1, object)
-    expected_output_ipython = 'Session: 11 https://central.xnat.org/data/experiments/CENTRAL_E04850/scans/11' \
-                              'Experiemnt: CENTRAL_E04850' \
-                              'Type: SPGR' \
-                              'Frames: 175' \
-                              'Series Description: SPGR' \
-                              'Field Strength: 3.0'
-    assert str(scan_1) == str(expected_output_ipython)
+    expected_output = '\n' + 'Scan: 11 https://central.xnat.org/data/projects/surfmask_smpl/subjects/CENTRAL_S01791' \
+                             '/experiments/CENTRAL_E04850/scans/11' \
+                      + '\n' + 'Experiment: CENTRAL_E04850' + '\n' + 'Type: SPGR' + '\n' + 'Frames: 175' \
+                      + '\n' + 'Series Description: SPGR' + '\n' + 'Field Strength: 3.0'
+    assert list(sorted(str(scan_1))) == list(sorted(expected_output))
 
 
 @skip_if_no_network
@@ -146,8 +134,7 @@ def test_resource_not_exists():
 
 
 @skip_if_no_network
-def test_info_experiment():
+def test_info_resource():
     assert isinstance(resource_1, object)
-    expected_output_ipython = 'Resource: obscure_algorithm_output ' \
-                              'Number of files: 66'
-    assert str(resource_1) == str(expected_output_ipython)
+    expected_output = '\n' + 'Resource: obscure_algorithm_output' + '\n' + 'Files: 66'
+    assert list(sorted(str(resource_1))) == list(sorted(expected_output))

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -8,9 +8,9 @@ fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 print(fp)
 central = Interface(config=fp)
 
-proj_1 = central.select.project('surfmask_smpl')
-subj_1 = proj_1.subject('CENTRAL_S01791')
-exp_1 = subj_1.experiment('CENTRAL_E04850')
+proj_1 = central.select.project('surfmask_smpl2')
+subj_1 = proj_1.subject('CENTRAL05_S01120')
+exp_1 = subj_1.experiment('CENTRAL05_E02681')
 scan_1 = exp_1.scan('11')
 resource_1 = exp_1.resource('obscure_algorithm_output')
 
@@ -38,10 +38,10 @@ def test_project_not_exists():
 @skip_if_no_network
 def test_info_project():
     assert isinstance(proj_1, object)
-    expected_output = '<Project Object> surfmask_smpl `Surface masking '\
-        'samples` (public) 43 subjects 43 MR experiments (owner: mmilch) '\
-        '(created on 2012-04-05 15:45:30.0) https://central.xnat.org/data/'\
-        'projects/surfmask_smpl?format=html'
+    expected_output = '<Project Object> surfmask_smpl2 `Surface masking '\
+        'samples 2` (private) 1 subject 1 MR experiment (owner: nosetests) '\
+        '(created on 2020-10-22 15:23:39.458) https://central.xnat.org/data/'\
+        'projects/surfmask_smpl2?format=html'
     assert list(sorted(str(proj_1))) == list(sorted(expected_output))
 
 
@@ -62,9 +62,9 @@ def test_subject_not_exists():
 @skip_if_no_network
 def test_info_subject():
     assert isinstance(subj_1, object)
-    expected_output = '<Subject Object> CENTRAL_S01791 `001` (project: '\
-        'surfmask_smpl) (Gender: U) 1 experiment https://central.xnat.org/'\
-        'data/projects/surfmask_smpl/subjects/CENTRAL_S01791?format=html'
+    expected_output = '<Subject Object> CENTRAL05_S01120 `001` (project: '\
+        'surfmask_smpl2) (Gender: U) 1 experiment https://central.xnat.org/'\
+        'data/projects/surfmask_smpl2/subjects/CENTRAL05_S01120?format=html'
     assert list(sorted(str(subj_1))) == list(sorted(expected_output))
 
 
@@ -85,11 +85,11 @@ def test_experiment_not_exists():
 @skip_if_no_network
 def test_info_experiment():
     assert isinstance(exp_1, object)
-    expected_output = '<Experiment Object> CENTRAL_E04850 `001_obscured` (subject: '\
-        'CENTRAL_S01791 `001`) (project: surfmask_smpl) 4 scans 1 resource '\
-        '(created on 2012-04-10 17:27:25.0) https://central.xnat.org/'\
-        'data/projects/surfmask_smpl/subjects/CENTRAL_S01791/experiments/'\
-        'CENTRAL_E04850?format=html'
+    expected_output = '<Experiment Object> CENTRAL05_E02681 `001_obscured` (subject: '\
+        'CENTRAL05_S01120 `001`) (project: surfmask_smpl2) 4 scans 1 resource '\
+        '(created on 2020-10-22 15:24:30.139) https://central.xnat.org/'\
+        'data/projects/surfmask_smpl2/subjects/CENTRAL05_S01120/experiments/'\
+        'CENTRAL05_E02681?format=html'
     assert list(sorted(str(exp_1))) == list(sorted(expected_output))
 
 
@@ -111,8 +111,8 @@ def test_scan_not_exists():
 def test_info_scan():
     assert isinstance(scan_1, object)
     expected_output = '<Scan Object> 11 (`SPGR` 175 frames)  '\
-        'https://central.xnat.org/data/projects/surfmask_smpl/subjects/'\
-        'CENTRAL_S01791/experiments/CENTRAL_E04850/scans/11?format=html'
+        'https://central.xnat.org/data/projects/surfmask_smpl2/subjects/'\
+        'CENTRAL05_S01120/experiments/CENTRAL05_E02681/scans/11?format=html'
     assert list(sorted(str(scan_1))) == list(sorted(expected_output))
 
 
@@ -133,7 +133,7 @@ def test_resource_not_exists():
 @skip_if_no_network
 def test_info_resource():
     assert isinstance(resource_1, object)
-    expected_output = '<Resource Object> 123221564 '\
+    expected_output = '<Resource Object> 123361501 '\
         '`obscure_algorithm_output` (66 files 2.06 GB)'
     assert list(sorted(str(resource_1))) == list(sorted(expected_output))
 

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -37,14 +37,10 @@ def test_project_not_exists():
 @skip_if_no_network
 def test_info_project():
     assert isinstance(proj_1, object)
-    expected_output = '\n' + 'Project: surfmask_smpl(Surface masking samples) ' \
-                             'https://central.xnat.org/data/projects/surfmask_smpl' \
-                      + '\n' + 'Subjects: 43' \
-                      + '\n' + 'Description: The collection of structural T1 MRI scans from &quot;Functional Data for ' \
-                               'Neurosurgical Planning&quot; (IGT_FMRI_NEURO) project processed with surface ' \
-                               'obscuring algorithm.' \
-                      + '\n' + 'Project owners:  mmilch ' + '\n' + 'Insert date: 2012-04-05 15:45:30.0' \
-                      + '\n' + 'Access: public' + '\n' + 'MR experiments: 43'
+    expected_output = '<Project Object> surfmask_smpl `Surface masking '\
+        'samples` (public) 43 subjects 43 MR experiments (owner: mmilch) '\
+        '(created on 2012-04-05 15:45:30.0) https://central.xnat.org/data/'\
+        'projects/surfmask_smpl'
     assert list(sorted(str(proj_1))) == list(sorted(expected_output))
 
 

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -61,10 +61,9 @@ def test_subject_not_exists():
 @skip_if_no_network
 def test_info_subject():
     assert isinstance(subj_1, object)
-    expected_output = '\n' + 'Subject: CENTRAL_S01791 https://central.xnat.org/data/projects/surfmask_smpl/subjects/' \
-                             'CENTRAL_S01791' \
-                      + '\n' + 'Project: surfmask_smpl' + '\n' + 'Insert user: mmilch' \
-                      + '\n' + 'Insert date: 2012-04-10 17:27:22.0' + '\n' + 'Gender: U'
+    expected_output = '<Subject Object> CENTRAL_S01791 `001` (project: '\
+        'surfmask_smpl) (Gender: U) 1 experiment https://central.xnat.org/'\
+        'data/projects/surfmask_smpl/subjects/CENTRAL_S01791'
     assert list(sorted(str(subj_1))) == list(sorted(expected_output))
 
 

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -109,9 +109,9 @@ def test_scan_not_exists():
 @skip_if_no_network
 def test_info_scan():
     assert isinstance(scan_1, object)
-    expected_output = '\n' + 'Scan: 11 https://central.xnat.org/data/projects/surfmask_smpl/subjects/CENTRAL_S01791' \
-                             '/experiments/CENTRAL_E04850/scans/11' \
-                      + '\n' + 'Experiment: CENTRAL_E04850' + '\n' + 'Type: SPGR' + '\n' + 'Frames: 175'
+    expected_output = '<Scan Object> 11 (`SPGR` 175 frames) '\
+        'https://central.xnat.org/data/projects/surfmask_smpl/subjects/'\
+        'CENTRAL_S01791/experiments/CENTRAL_E04850/scans/11'
     assert list(sorted(str(scan_1))) == list(sorted(expected_output))
 
 

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -37,12 +37,14 @@ def test_project_not_exists():
 @skip_if_no_network
 def test_info_project():
     assert isinstance(proj_1, object)
-    expected_output = '\n' + 'Project: surfmask_smpl(Surface masking samples) \
-    https://central.xnat.org/data/projects/surfmask_smpl' + '\n' + 'Subjects: 43' \
-                      + '\n' + 'Description: The collection of structural T1 MRI scans from &quot;Functional \
-    Data for Neurosurgical Planning&quot; (IGT_FMRI_NEURO) project processed with surface \
-    obscuring algorithm.' + '\n' + 'Project owners:  mmilch ' + '\n' + \
-                      'Insert date: 2012-04-05 15:45:30.0' + '\n' + 'Access: public' + '\n' + 'MR experiments: 43'
+    expected_output = '\n' + 'Project: surfmask_smpl(Surface masking samples) ' \
+                             'https://central.xnat.org/data/projects/surfmask_smpl' \
+                      + '\n' + 'Subjects: 43' \
+                      + '\n' + 'Description: The collection of structural T1 MRI scans from &quot;Functional Data for ' \
+                               'Neurosurgical Planning&quot; (IGT_FMRI_NEURO) project processed with surface ' \
+                               'obscuring algorithm.' \
+                      + '\n' + 'Project owners:  mmilch ' + '\n' + 'Insert date: 2012-04-05 15:45:30.0' \
+                      + '\n' + 'Access: public' + '\n' + 'MR experiments: 43'
     assert list(sorted(str(proj_1))) == list(sorted(expected_output))
 
 

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -85,7 +85,7 @@ def test_experiment_not_exists():
 @skip_if_no_network
 def test_info_experiment():
     assert isinstance(exp_1, object)
-    expected_output = '<Experiment Object> CENTRAL_E04850 (subject: '\
+    expected_output = '<Experiment Object> CENTRAL_E04850 `001_obscured` (subject: '\
         'CENTRAL_S01791 `001`) (project: surfmask_smpl) 4 scans 1 resource '\
         '(created on 2012-04-10 17:27:25.0) https://central.xnat.org/'\
         'data/projects/surfmask_smpl/subjects/CENTRAL_S01791/experiments/'\

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -132,5 +132,6 @@ def test_resource_not_exists():
 @skip_if_no_network
 def test_info_resource():
     assert isinstance(resource_1, object)
-    expected_output = '\n' + 'Resource: obscure_algorithm_output' + '\n' + 'Files: 66'
+    expected_output = '<Resource Object> obscure_algorithm_output '\
+        '`obscure_algorithm_output` (66 files)'
     assert list(sorted(str(resource_1))) == list(sorted(expected_output))

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -116,8 +116,7 @@ def test_info_scan():
     assert isinstance(scan_1, object)
     expected_output = '\n' + 'Scan: 11 https://central.xnat.org/data/projects/surfmask_smpl/subjects/CENTRAL_S01791' \
                              '/experiments/CENTRAL_E04850/scans/11' \
-                      + '\n' + 'Experiment: CENTRAL_E04850' + '\n' + 'Type: SPGR' + '\n' + 'Frames: 175' \
-                      + '\n' + 'Series Description: SPGR' + '\n' + 'Field Strength: 3.0'
+                      + '\n' + 'Experiment: CENTRAL_E04850' + '\n' + 'Type: SPGR' + '\n' + 'Frames: 175'
     assert list(sorted(str(scan_1))) == list(sorted(expected_output))
 
 

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -1,0 +1,153 @@
+from pyxnat import Interface
+import os.path as op
+from . import skip_if_no_network
+from IPython import get_ipython
+
+_modulepath = op.dirname(op.abspath(__file__))
+
+central = Interface(config=op.join(op.dirname(op.abspath(__file__)),
+                                   '.xnat-central.cfg'))
+
+proj_1 = central.select.project('CENTRAL_OASIS_CS')
+subj_1 = proj_1.subject('OAS1_0002')
+exp_1 = subj_1.experiments('OAS1_0002_MR1')
+scan_1 = exp_1.scan('mpr-1')
+resource_1 = scan_1.resource('')
+
+proj_2 = central.select.project('NFB')
+subj_2 = proj_2.subject('BOA')
+exp_2 = subj_2.experiment('GHJ')
+scan_2 = exp_2.scan('JKL')
+resource_2 = scan_2.resource('IOP')
+
+
+@skip_if_no_network
+def test_project_exists():
+    if proj_1.exists():
+        assert isinstance(proj_1, object)
+        assert str(proj_1) != '<Project Object> NFB'
+
+
+@skip_if_no_network
+def test_project_not_exists():
+    if not proj_2.exists():
+        assert isinstance(proj_2, object)
+        assert str(proj_2) == '<Project Object> NFB'
+
+
+@skip_if_no_network
+def test_info_project():
+    assert isinstance(proj_1, object)
+    expected_output_ipython = 'Project: surfmask_smpl(Surface masking samples) ' \
+                              'https://central.xnat.org/data/projects/surfmask_smpl ' \
+                              'Subjects: 43' \
+                              'Description: The collection of structural T1 MRI scans from &quot;Functional Data for ' \
+                              'Neurosurgical Planning&quot; (IGT_FMRI_NEURO) project processed with surface obscuring ' \
+                              'a' \
+                              'Project owners:  mmilch' \
+                              'Insert date: 2012-04-05 15:45:30.0' \
+                              'Access: public' \
+                              'MR experiments: 43'
+    assert str(proj_1) == str(expected_output_ipython)
+
+
+@skip_if_no_network
+def test_subject_exists():
+    if subj_1.exists():
+        assert isinstance(subj_1, object)
+        assert str(subj_1) != '<Subject Object> BOA'
+
+
+@skip_if_no_network
+def test_subject_not_exists():
+    if not subj_2.exists():
+        assert isinstance(subj_2, object)
+        assert str(subj_2) == '<Subject Object> BOA'
+
+
+@skip_if_no_network
+def test_info_subject():
+    assert isinstance(subj_1, object)
+    expected_output_ipython = 'Subject: CENTRAL_S01791 https://central.xnat.org/data/projects/surfmask_smpl/subjects' \
+                              '/CENTRAL_S01791' \ 
+                              'Project: surfmask_smpl' \
+                              'Insert user: mmilch' \
+                              'Insert date: 2012-04-10 17:27:22.0' \
+                              'Gender: U'
+    assert str(subj_1) == str(expected_output_ipython)
+
+
+@skip_if_no_network
+def test_experiment_exists():
+    if exp_1.exists():
+        assert isinstance(exp_1, object)
+        assert str(exp_1) != '<Experiment Object> GHJ'
+
+
+@skip_if_no_network
+def test_experiment_not_exists():
+    if not exp_2.exists():
+        assert isinstance(exp_2, object)
+        assert str(exp_2) == '<Experiment Object> GHJ'
+
+
+@skip_if_no_network
+def test_info_experiment():
+    assert isinstance(exp_1, object)
+    expected_output_ipython = 'Session: CENTRAL_E04850 https://central.xnat.org/data/experiments/CENTRAL_E04850' \
+                              'Subject: CENTRAL_S01791' \
+                              'Project: surfmask_smpl' \
+                              'Scans: 4' \
+                              'Insert user: mmilch' \
+                              'Insert date:  2012-04-10 17:27:25.0' \
+                              'Date: 2008-05-06' \
+                              'Type: IGT_FMRI_NEURO'
+    assert str(exp_1) == str(expected_output_ipython)
+
+
+@skip_if_no_network
+def test_scan_exists():
+    if scan_1.exists():
+        assert isinstance(scan_1, object)
+        assert str(scan_1) != '<Scan Object> JKL'
+
+
+@skip_if_no_network
+def test_scan_not_exists():
+    if not scan_2.exists():
+        assert isinstance(scan_2, object)
+        assert str(scan_2) == '<Scan Object> JKL'
+
+
+@skip_if_no_network
+def test_info_scan():
+    assert isinstance(scan_1, object)
+    expected_output_ipython = 'Session: 11 https://central.xnat.org/data/experiments/CENTRAL_E04850/scans/11' \
+                              'Experiemnt: CENTRAL_E04850' \
+                              'Type: SPGR' \
+                              'Frames: 175' \
+                              'Series Description: SPGR' \
+                              'Field Strength: 3.0'
+    assert str(scan_1) == str(expected_output_ipython)
+
+
+@skip_if_no_network
+def test_resource_exists():
+    if resource_1.exists():
+        assert isinstance(resource_1, object)
+        assert str(resource_1) != '<Resource Object> IOP'
+
+
+@skip_if_no_network
+def test_resource_not_exists():
+    if not resource_2.exists():
+        assert isinstance(resource_2, object)
+        assert str(resource_2) == '<Resource Object> IOP'
+
+
+@skip_if_no_network
+def test_info_experiment():
+    assert isinstance(resource_1, object)
+    expected_output_ipython = 'Resource: obscure_algorithm_output ' \
+                              'Number of files: 66'
+    assert str(resource_1) == str(expected_output_ipython)

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -6,7 +6,7 @@ from IPython import get_ipython
 _modulepath = op.dirname(op.abspath(__file__))
 
 central = Interface(config=op.join(op.dirname(op.abspath(__file__)),
-                                   '.xnat-central.cfg'))
+                                   'central.cfg'))
 
 proj_1 = central.select.project('CENTRAL_OASIS_CS')
 subj_1 = proj_1.subject('OAS1_0002')

--- a/pyxnat/tests/repr_tests.py
+++ b/pyxnat/tests/repr_tests.py
@@ -136,3 +136,17 @@ def test_info_resource():
     expected_output = '<Resource Object> obscure_algorithm_output '\
         '`obscure_algorithm_output` (66 files)'
     assert list(sorted(str(resource_1))) == list(sorted(expected_output))
+
+
+@skip_if_no_network
+def test_create_delete_create():
+    p = central.select.project('nosetests5')
+    from uuid import uuid1
+    sid = uuid1().hex
+    s = p.subject(sid)
+    s.create()
+    assert(s.exists())
+    s.delete()
+    s.create()
+    s.delete()
+    assert(not s.exists())

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -6,6 +6,7 @@ import os
 from pyxnat import Interface
 from . import skip_if_no_network
 from nose import SkipTest
+import time
 from pyxnat.core import interfaces
 
 _modulepath = op.dirname(op.abspath(__file__))
@@ -29,7 +30,8 @@ _id_set2 = {
     'cid': uuid1().hex,
     'rid': uuid1().hex,
     }
-subj_1 = central.select.project('nosetests3').subject(_id_set1['sid'])
+
+subj_1 = central.select.project('nosetests5').subject(_id_set1['sid'])
 expe_1 = subj_1.experiment(_id_set1['eid'])
 asse_1 = expe_1.assessor(_id_set1['aid'])
 scan_1 = expe_1.scan(_id_set1['cid'])
@@ -78,14 +80,12 @@ def test_05_reconstruction_create():
 
 @skip_if_no_network
 def test_06_multi_create():
-    asse_2 = central.select('/projects/nosetests3/subjects/%(sid)s'
+    asse_2 = central.select('/projects/nosetests5/subjects/%(sid)s'
                             '/experiments/%(eid)s'
-                            '/assessors/%(aid)s' % _id_set2
-                            )
+                            '/assessors/%(aid)s' % _id_set2)
 
-    expe_2 = central.select('/projects/nosetests3/subjects/%(sid)s'
-                            '/experiments/%(eid)s' % _id_set2
-                            )
+    expe_2 = central.select('/projects/nosetests5/subjects/%(sid)s'
+                            '/experiments/%(eid)s' % _id_set2)
 
     assert not asse_2.exists()
     asse_2.create(experiments='xnat:petSessionData',
@@ -95,7 +95,7 @@ def test_06_multi_create():
     assert asse_2.datatype() == 'xnat:petAssessorData'
     assert expe_2.datatype() == 'xnat:petSessionData'
 
-    scan_2 = central.select('/projects/nosetests3/subjects/%(sid)s'
+    scan_2 = central.select('/projects/nosetests5/subjects/%(sid)s'
                             '/experiments/%(eid)s/scans/%(cid)s' % _id_set2
                             ).create()
 
@@ -242,10 +242,10 @@ def test_12_file_last_modified():
 def test_13_last_modified():
     sid = subj_1.id()
 
-    t1 = central.select('/project/nosetests3').last_modified()[sid]
+    t1 = central.select('/project/nosetests5').last_modified()[sid]
     subj_1.attrs.set('age', '26')
     assert subj_1.attrs.get('age') == '26'
-    t2 = central.select('/project/nosetests3').last_modified()[sid]
+    t2 = central.select('/project/nosetests5').last_modified()[sid]
 
     assert t1 != t2
 
@@ -272,12 +272,12 @@ def test_15_getitem_slice():
 
 
 def test_subject1_parent():
-    project = central.select.project('nosetests3')
+    project = central.select.project('nosetests5')
     assert subj_1.parent()._uri == project._uri
 
 
 def test_project_parent():
-    project = central.select.project('nosetests3')
+    project = central.select.project('nosetests5')
     assert not project.parent()
 
 
@@ -290,7 +290,7 @@ def test_16_subject1_delete():
 
 @skip_if_no_network
 def test_17_subject2_delete():
-    subj_2 = central.select('/projects/nosetests3/subjects/%(sid)s' % _id_set2)
+    subj_2 = central.select('/projects/nosetests5/subjects/%(sid)s' % _id_set2)
     assert subj_2.exists()
     subj_2.delete()
     assert not subj_2.exists()
@@ -298,7 +298,7 @@ def test_17_subject2_delete():
 
 @skip_if_no_network
 def test_18_project_configuration():
-    project = central.select('/project/nosetests3')
+    project = central.select('/project/nosetests5')
     version = central.version()
     from pyxnat.core.errors import DatabaseError
 
@@ -365,13 +365,13 @@ def test_20_get_zip():
 
 @skip_if_no_network
 def test_21_project_aliases():
-    project = central.select('/project/nosetests3')
-    assert project.aliases() == ['nosetests32']
+    project = central.select('/project/nosetests5')
+    assert project.aliases() == ['nosetests52']
 
 
 @skip_if_no_network
 def test_22_project():
-    project = central.select.project('nosetests3')
+    project = central.select.project('nosetests5')
     project.datatype()
     project.experiments()
     project.experiment('nose')

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -375,3 +375,10 @@ def test_22_project():
     project.datatype()
     project.experiments()
     project.experiment('nose')
+
+
+@skip_if_no_network
+def test_22_project_description():
+    project = central.select.project('nosetests5')
+    desc = project.description()
+    assert(desc == 'nosetests')

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -6,7 +6,6 @@ import os
 from pyxnat import Interface
 from . import skip_if_no_network
 from nose import SkipTest
-import time
 from pyxnat.core import interfaces
 
 _modulepath = op.dirname(op.abspath(__file__))

--- a/pyxnat/tests/test_resource_functions.py
+++ b/pyxnat/tests/test_resource_functions.py
@@ -6,7 +6,7 @@ fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 central = Interface(config=fp)
 
 def test_ashs_volumes():
-    r = central.select.experiment('CENTRAL04_E00637').resource('ASHS')
+    r = central.select.experiment('CENTRAL02_E01603').resource('ASHS')
     hv = r.volumes()
     v = hv.query('region=="CA1" & side=="left"')['volume'].tolist()[0]
-    assert(v == 1585.838)
+    assert(v == 1287.675)

--- a/pyxnat/tests/user_and_project_management_test.py
+++ b/pyxnat/tests/user_and_project_management_test.py
@@ -70,24 +70,24 @@ def test_user_id():
 @docker_available
 def test_add_remove_user():
     x = Interface(config='.xnat.cfg')
-    x.select.project('nosetests3').remove_user('admin')
-    x.select.project('nosetests3').add_user('admin', 'collaborator')
-    assert 'admin' in x.select.project('nosetests3').collaborators()
-    x.select.project('nosetests3').remove_user('admin')
-    assert 'admin' not in x.select.project('nosetests3').collaborators()
-    x.select.project('nosetests3').add_user('admin', 'owner')
+    x.select.project('nosetests5').remove_user('admin')
+    x.select.project('nosetests5').add_user('admin', 'collaborator')
+    assert 'admin' in x.select.project('nosetests5').collaborators()
+    x.select.project('nosetests5').remove_user('admin')
+    assert 'admin' not in x.select.project('nosetests5').collaborators()
+    x.select.project('nosetests5').add_user('admin', 'owner')
 
 
 @docker_available
 def test_project_accessibility():
     x = Interface(config='.xnat.cfg')
-    print(x.select.project('nosetests3').accessibility())
-    assert x.select.project('nosetests3').accessibility() in \
+    print(x.select.project('nosetests5').accessibility())
+    assert x.select.project('nosetests5').accessibility() in \
            [b'public', b'protected', b'private']
-    x.select.project('nosetests3').set_accessibility('private')
-    assert x.select.project('nosetests3').accessibility() == b'private'
-    x.select.project('nosetests3').set_accessibility('protected')
-    assert x.select.project('nosetests3').accessibility() == b'protected'
+    x.select.project('nosetests5').set_accessibility('private')
+    assert x.select.project('nosetests5').accessibility() == b'private'
+    x.select.project('nosetests5').set_accessibility('protected')
+    assert x.select.project('nosetests5').accessibility() == b'protected'
 
 
 @docker_available
@@ -106,25 +106,25 @@ def test_create_xml():
 
 def test_project_users():
     x = Interface(config=fp)
-    assert isinstance(x.select.project('nosetests3').users(), list)
+    assert isinstance(x.select.project('nosetests5').users(), list)
 
 
 def test_project_owners():
     x = Interface(config=fp)
-    assert isinstance(x.select.project('nosetests3').owners(), list)
+    assert isinstance(x.select.project('nosetests5').owners(), list)
 
 
 def test_project_members():
     x = Interface(config=fp)
-    assert isinstance(x.select.project('nosetests3').members(), list)
+    assert isinstance(x.select.project('nosetests5').members(), list)
 
 
 def test_project_collaborators():
     x = Interface(config=fp)
-    assert isinstance(x.select.project('nosetests3').collaborators(),
+    assert isinstance(x.select.project('nosetests5').collaborators(),
                       list)
 
 
 def test_project_user_role():
     x = Interface(config=fp)
-    assert x.select.project('nosetests3').user_role('nosetests') == 'owner'
+    assert x.select.project('nosetests5').user_role('nosetests') == 'owner'


### PR DESCRIPTION
**Problem**

When we call the object pyxnat it returns just a collection object and an ID number.

**Feature**

We want to return more information (metadata information) from the object. Some metadata information examples are the age, gender, handedness, insert data, insert user, number of subjects, experiments, scans...etc.

**Solution**

The changes has been done in the resources.py file.
A repr method has been added to each class (Project, Subject, Experiment, Scan and Resource).
Each method is capable to return the main information for each object dynamically (will just appear the information that the object contains, the empty fields will not appear) and a link that redirects you to the XNAT page where the object is.
This method allows us to know more information about the object immediately and find out more just clicking the link.

**Unit Tests**

For each object, 3 tests cases has been added. So in total, we have 15 unit tests in a new file tests/repr_test.py.
The tests check if the object exist, if the object does not exist and if it exists that the information that returns is correct.