### PR TITLE
REF: Always use the shorten URI when creating a project experiment

### DIFF
--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1210,15 +1210,9 @@ class Project(EObject):
         dp = datapath % (self._intf._get_entry_point(), self.id(), ID)
 
         tmp = Experiment(dp, self._intf)
-        if tmp.id() == ID:
-            return tmp
-        else:
-            # if id id not mach given id (which may have been a label
-            # re-select with the ID of the matching experiment.
-            return Experiment(datapath % (
-                self._intf._get_entry_point(), self.id(), tmp.id()),
-                self._intf
-                )
+        e_uri = '%s/experiments/%s' % (self._intf._get_entry_point(),
+                                       tmp.id())
+        return Experiment(e_uri, self._intf)
 
     def last_modified(self):
         """ Gets the last modified dates for all the project subjects.

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -390,3 +390,40 @@ def test_23_project_experiment():
            len(list(e3.resources())) ==
            len(list(e4.resources())))
 
+@skip_if_no_network
+def test_24_share_subject():
+    from pyxnat.core.errors import DatabaseError
+
+    proj_a = central.select.project('nosetests3')
+    proj_b = central.select.project('metabase_nosetests')
+    subj_a = proj_a.subject('rs')
+
+    # always unshare at the begining just in case of abnormal termination
+    try:
+        proj_a.subjects().unshare('metabase_nosetests')
+    except DatabaseError:
+        pass
+    assert not proj_b.subject('rs').exists()
+    subj_a.share('metabase_nosetests')
+    assert proj_b.subject('rs').exists()
+    assert set(subj_a.shares().get()) == set(['nosetests3', 'metabase_nosetests'])
+    subj_a.unshare('metabase_nosetests')
+
+@skip_if_no_network
+def test_25_share_experiment():
+    from pyxnat.core.errors import DatabaseError
+
+    proj_a = central.select.project('nosetests3')
+    proj_b = central.select.project('metabase_nosetests')
+    exp_a = proj_a.experiment('rs_MR1')
+
+    # always unshare at the begining just in case of abnormal termination
+    try:
+        proj_a.experiments().unshare('metabase_nosetests')
+    except DatabaseError:
+        pass
+    assert not proj_b.experiment('rs_MR1').exists()
+    exp_a.share('metabase_nosetests')
+    assert proj_b.experiment('rs_MR1').exists()
+    assert set(exp_a.shares().get()) == set(['nosetests3', 'metabase_nosetests'])
+    exp_a.unshare('metabase_nosetests')

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -375,3 +375,18 @@ def test_22_project():
     project.datatype()
     project.experiments()
     project.experiment('nose')
+
+
+@skip_if_no_network
+def test_23_project_experiment():
+    e1 = central.select.experiment('CENTRAL04_E00637')
+    e2 = central.select.project('nosetests3').experiment('CENTRAL04_E00637')
+    e3 = central.select.project('nosetests3').experiment('rs_MR1')
+    assert (e1._uri == e2._uri == e3._uri)
+
+    e4 = central.select.project('nosetests3').subject('rs').experiment('rs_MR1')
+    assert(len(list(e1.resources())) ==
+           len(list(e2.resources())) ==
+           len(list(e3.resources())) ==
+           len(list(e4.resources())))
+


### PR DESCRIPTION
Closes #142 

Content,
* Fix proposal for issue #142, modifying the instantiation mechanism of Project's experiments.
* New test checking the proper URI composition of Project experiment objects (issue #142)
* [Unrelated/extra] Addition of few tests checking Subjects and Experiments `sharing` feature among projects (coverage ratio)
