### PR TITLE
Mirroring PET sessions

### DIFF
--- a/bin/sessionmirror.py
+++ b/bin/sessionmirror.py
@@ -179,8 +179,8 @@ PET_EXP_ATTRS = [
     'xnat:petSessionData/patientID',
     'xnat:petSessionData/patientName',
     'xnat:petSessionData/stabilization',
-    # 'xnat:petSessionData/start_time/scan',
-    # 'xnat:petSessionData/start_time/injection',
+    'xnat:petSessionData/start_time_scan',
+    'xnat:petSessionData/start_time_injection',
     'xnat:petSessionData/tracer/name',
     'xnat:petSessionData/tracer/startTime',
     'xnat:petSessionData/tracer/dose',
@@ -190,7 +190,7 @@ PET_EXP_ATTRS = [
     'xnat:petSessionData/tracer/isotope',
     'xnat:petSessionData/tracer/isotope/half-life',
     'xnat:petSessionData/tracer/transmissions'
-    # 'xnat:petSessionData/tracer/transmissions/startTime'
+    'xnat:petSessionData/tracer/transmissions_starttime'
 ]
 
 CT_EXP_ATTRS = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,6 @@ nose>=1.2.1
 coverage>=3.6
 coveralls
 # extras
+pandas>=0.24
 networkx>=2.2
 matplotlib>=2.2
-pandas>=0.24


### PR DESCRIPTION
Minor PR focused on `sessionmirror.py` bin script,
* FIX: ~Exclude~ Repair PETSession attributes which XNAT fail to pull via ```src_attrs = src_obj.attrs.mget(attr_list)```
* FIX: Destination experiment created twice (by default as an MRSession)
* PEP8-based minor additional changes