### PR TITLE
Share primary

### DIFF
--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1538,7 +1538,7 @@ class Subject(EObject):
             options.append('primary=true')
 
         options = '?' + '&'.join(options)
-        print(join_uri(self._uri, 'projects', project) + options)
+
         self._intf._exec(join_uri(self._uri, 'projects', project) + options, 'PUT')
 
 
@@ -1660,7 +1660,7 @@ class Experiment(EObject):
             options.append('primary=true')
 
         options = '?' + '&'.join(options)
-        print(join_uri(self._uri, 'projects', project) + options)
+
         self._intf._exec(join_uri(self._uri, 'projects', project) + options, 'PUT')
 
 
@@ -1734,16 +1734,31 @@ class Assessor(EObject):
         return Projects(join_uri(self._uri, 'projects'),
                         self._intf, id_filter)
 
-    def share(self, project):
+    def share(self, project, label=None, primary=False):
         """ Share this assessor with another project.
 
             Parameters
             ----------
                 project: string
                     The other project name.
+                label: string
+                    New label of assessor. If empty the label of the experiment will be reused
+                primary: boolean
+                    If True, the primary ownership of the assessor will be changed from the original project to the
+                    new project. Logged-in user must have ownership permissions in both projects to change the primary
+                    ownership.
         """
-        #self._intf._exec(join_uri(self._uri, 'projects', project), 'PUT')
-        self._intf._exec(join_uri(self._uri, 'projects', project) + '?primary=True', 'PUT')
+        options = []
+        if label:
+            options.append('label=%s' % label)
+        else:
+            options.append('label=%s' % self._urn)
+        if primary:
+            options.append('primary=true')
+
+        options = '?' + '&'.join(options)
+
+        self._intf._exec(join_uri(self._uri, 'projects', project) + options, 'PUT')
 
     def unshare(self, project):
         """ Remove assessor from another project in which it was shared.

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1734,52 +1734,6 @@ class Assessor(EObject):
 
         self.provenance = Provenance(self)
 
-    def shares(self, id_filter='*'):
-        """ Returns the projects sharing this assessor.
-
-            Returns
-            -------
-            Collection object.
-        """
-        return Projects(join_uri(self._uri, 'projects'),
-                        self._intf, id_filter)
-
-    def share(self, project, label=None, primary=False):
-        """ Share this assessor with another project.
-
-            Parameters
-            ----------
-                project: string
-                    The other project name.
-                label: string
-                    New label of assessor. If empty the label of the experiment will be reused
-                primary: boolean
-                    If True, the primary ownership of the assessor will be changed from the original project to the
-                    new project. Logged-in user must have ownership permissions in both projects to change the primary
-                    ownership.
-        """
-        options = []
-        if label:
-            options.append('label=%s' % label)
-        else:
-            options.append('label=%s' % self._urn)
-        if primary:
-            options.append('primary=true')
-
-        options = '?' + '&'.join(options)
-
-        self._intf._exec(join_uri(self._uri, 'projects', project) + options, 'PUT')
-
-    def unshare(self, project):
-        """ Remove assessor from another project in which it was shared.
-
-            Parameters
-            ----------
-                project: string
-                    The other project name.
-        """
-        self._intf._exec(join_uri(self._uri, 'projects', project), 'DELETE')
-
     def set_param(self, key, value):
         self.attrs.set('%s/parameters/addParam[name=%s]/addField'
                        % (self.datatype(), key),
@@ -2455,21 +2409,6 @@ class Experiments(CObject):
 
 @add_metaclass(CollectionType)
 class Assessors(CObject):
-
-    def sharing(self, projects=[]):
-        return Assessors([eobj for eobj in self
-                          if set(projects).issubset(eobj.shares().get())
-                          ],
-                         self._intf
-                         )
-
-    def share(self, project):
-        for eobj in self:
-            eobj.share(project)
-
-    def unshare(self, project):
-        for eobj in self:
-            eobj.unshare(project)
 
     def download(self, dest_dir, type="ALL",
                  name=None, extract=False, safe=False, removeZip=False):

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1515,41 +1515,46 @@ class Subject(EObject):
         return Projects(join_uri(self._uri, 'projects'),
                         self._intf, id_filter)
 
-    def share(self, project, label=None, primary=False):
-        """ Share this subject with another project.
+    def share(self, project, label=None):
+        """ Share the subject with another project.
 
             Parameters
             ----------
                 project: string
-                    The other project name.
+                    Target project name.
                 label: string
-                    New label of subject. If empty the label of the subject will be reused
-                primary: boolean
-                    If True, the primary ownership of the subject will be changed from the original project to the
-                    new project. Logged-in user must have ownership permissions in both projects to change the primary
-                    ownership.
+                    Subject label as shared resource. By default, the original
+                    subject label is used.
         """
+        owner_project = self.attrs.get('project')
+        aliases = self._intf.select.project(owner_project).aliases()
+        if project in [owner_project] + aliases:
+            raise ValueError("Cannot share a subject with its owner project.")
+
         options = []
         if label:
             options.append('label=%s' % label)
         else:
-            options.append('label=%s' % self._urn)
-        if primary:
-            options.append('primary=true')
+            options.append('label=%s' % self.label())
 
         options = '?' + '&'.join(options)
 
         self._intf._exec(join_uri(self._uri, 'projects', project) + options, 'PUT')
 
-
     def unshare(self, project):
-        """ Remove subject from another project in which it was shared.
+        """ Unlink subject from a project it was shared with. Subject cannot be
+            unshared from the project that owns it.
 
             Parameters
             ----------
                 project: string
-                    The other project name.
+                    Target project name.
         """
+        owner_project = self.attrs.get('project')
+        aliases = self._intf.select.project(owner_project).aliases()
+        if project in [owner_project] + aliases:
+            raise ValueError("Cannot unlink a subject from its owner project.")
+
         self._intf._exec(join_uri(self._uri, 'projects', project), 'DELETE')
 
 
@@ -1637,41 +1642,46 @@ class Experiment(EObject):
         return Projects(join_uri(self._uri, 'projects'),
                         self._intf, id_filter)
 
-    def share(self, project, label=None, primary=False):
-        """ Share this experiment with another project.
+    def share(self, project, label=None):
+        """ Share the experiment with another project.
 
             Parameters
             ----------
                 project: string
-                    The other project name.
+                    Target project name.
                 label: string
-                    New label of experiment. If empty the label of the experiment will be reused
-                primary: boolean
-                    If True, the primary ownership of the experiment will be changed from the original project to the
-                    new project. Logged-in user must have ownership permissions in both projects to change the primary
-                    ownership.
+                    Experiment label as shared resource. By default, the original
+                    experiment label is used.
         """
+        owner_project = self.attrs.get('project')
+        aliases = self._intf.select.project(owner_project).aliases()
+        if project in [owner_project] + aliases:
+            raise ValueError("Cannot share an experiment with its owner project.")
+
         options = []
         if label:
             options.append('label=%s' % label)
         else:
-            options.append('label=%s' % self._urn)
-        if primary:
-            options.append('primary=true')
+            options.append('label=%s' % self.label())
 
         options = '?' + '&'.join(options)
 
         self._intf._exec(join_uri(self._uri, 'projects', project) + options, 'PUT')
 
-
     def unshare(self, project):
-        """ Remove experiment from another project in which it was shared.
+        """ Unlink experiment from a project it was shared with. Experiment cannot
+            be unshared from the project that owns it.
 
             Parameters
             ----------
                 project: string
-                    The other project name.
+                    Target project name.
         """
+        owner_project = self.attrs.get('project')
+        aliases = self._intf.select.project(owner_project).aliases()
+        if project in [owner_project] + aliases:
+            raise ValueError("Cannot unlink an experiment from its owner project.")
+
         self._intf._exec(join_uri(self._uri, 'projects', project), 'DELETE')
 
     def trigger_pipelines(self):

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1515,15 +1515,32 @@ class Subject(EObject):
         return Projects(join_uri(self._uri, 'projects'),
                         self._intf, id_filter)
 
-    def share(self, project):
+    def share(self, project, label=None, primary=False):
         """ Share this subject with another project.
 
             Parameters
             ----------
                 project: string
                     The other project name.
+                label: string
+                    New label of subject. If empty the label of the subject will be reused
+                primary: boolean
+                    If True, the primary ownership of the subject will be changed from the original project to the
+                    new project. Logged-in user must have ownership permissions in both projects to change the primary
+                    ownership.
         """
-        self._intf._exec(join_uri(self._uri, 'projects', project), 'PUT')
+        options = []
+        if label:
+            options.append('label=%s' % label)
+        else:
+            options.append('label=%s' % self._urn)
+        if primary:
+            options.append('primary=true')
+
+        options = '?' + '&'.join(options)
+        print(join_uri(self._uri, 'projects', project) + options)
+        self._intf._exec(join_uri(self._uri, 'projects', project) + options, 'PUT')
+
 
     def unshare(self, project):
         """ Remove subject from another project in which it was shared.
@@ -1620,15 +1637,32 @@ class Experiment(EObject):
         return Projects(join_uri(self._uri, 'projects'),
                         self._intf, id_filter)
 
-    def share(self, project):
+    def share(self, project, label=None, primary=False):
         """ Share this experiment with another project.
 
             Parameters
             ----------
                 project: string
                     The other project name.
+                label: string
+                    New label of experiment. If empty the label of the experiment will be reused
+                primary: boolean
+                    If True, the primary ownership of the experiment will be changed from the original project to the
+                    new project. Logged-in user must have ownership permissions in both projects to change the primary
+                    ownership.
         """
-        self._intf._exec(join_uri(self._uri, 'projects', project), 'PUT')
+        options = []
+        if label:
+            options.append('label=%s' % label)
+        else:
+            options.append('label=%s' % self._urn)
+        if primary:
+            options.append('primary=true')
+
+        options = '?' + '&'.join(options)
+        print(join_uri(self._uri, 'projects', project) + options)
+        self._intf._exec(join_uri(self._uri, 'projects', project) + options, 'PUT')
+
 
     def unshare(self, project):
         """ Remove experiment from another project in which it was shared.
@@ -1708,7 +1742,8 @@ class Assessor(EObject):
                 project: string
                     The other project name.
         """
-        self._intf._exec(join_uri(self._uri, 'projects', project), 'PUT')
+        #self._intf._exec(join_uri(self._uri, 'projects', project), 'PUT')
+        self._intf._exec(join_uri(self._uri, 'projects', project) + '?primary=True', 'PUT')
 
     def unshare(self, project):
         """ Remove assessor from another project in which it was shared.

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1515,7 +1515,7 @@ class Subject(EObject):
         return Projects(join_uri(self._uri, 'projects'),
                         self._intf, id_filter)
 
-    def share(self, project, label=None):
+    def share(self, project, label=None, primary=False):
         """ Share the subject with another project.
 
             Parameters
@@ -1525,6 +1525,10 @@ class Subject(EObject):
                 label: string
                     Subject label as shared resource. By default, the original
                     subject label is used.
+                primary: boolean
+                    If True, the ownership of the subject will be transferred to
+                    the target project. User must be owner of both projects to
+                    perform this operation.
         """
         owner_project = self.attrs.get('project')
         aliases = self._intf.select.project(owner_project).aliases()
@@ -1536,6 +1540,8 @@ class Subject(EObject):
             options.append('label=%s' % label)
         else:
             options.append('label=%s' % self.label())
+        if primary:
+            options.append('primary=true')
 
         options = '?' + '&'.join(options)
 
@@ -1642,7 +1648,7 @@ class Experiment(EObject):
         return Projects(join_uri(self._uri, 'projects'),
                         self._intf, id_filter)
 
-    def share(self, project, label=None):
+    def share(self, project, label=None, primary=False):
         """ Share the experiment with another project.
 
             Parameters
@@ -1652,6 +1658,10 @@ class Experiment(EObject):
                 label: string
                     Experiment label as shared resource. By default, the original
                     experiment label is used.
+                primary: boolean
+                    If True, the ownership of the subject will be transferred to
+                    the target project. User must be owner of both projects to
+                    perform this operation.
         """
         owner_project = self.attrs.get('project')
         aliases = self._intf.select.project(owner_project).aliases()
@@ -1663,6 +1673,8 @@ class Experiment(EObject):
             options.append('label=%s' % label)
         else:
             options.append('label=%s' % self.label())
+        if primary:
+            options.append('primary=true')
 
         options = '?' + '&'.join(options)
 

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -20,7 +20,7 @@ _id_set1 = {
     'aid': uuid1().hex,
     'cid': uuid1().hex,
     'rid': uuid1().hex,
-    }
+}
 
 _id_set2 = {
     'sid': uuid1().hex,
@@ -28,7 +28,7 @@ _id_set2 = {
     'aid': uuid1().hex,
     'cid': uuid1().hex,
     'rid': uuid1().hex,
-    }
+}
 
 subj_1 = central.select.project('nosetests5').subject(_id_set1['sid'])
 expe_1 = subj_1.experiment(_id_set1['eid'])
@@ -232,22 +232,7 @@ def test_project_parent():
 
 
 @skip_if_no_network
-def test_16_subject1_delete():
-    assert subj_1.exists()
-    subj_1.delete()
-    assert not subj_1.exists()
-
-
-@skip_if_no_network
-def test_17_subject2_delete():
-    subj_2 = central.select('/projects/nosetests5/subjects/%(sid)s' % _id_set2)
-    assert subj_2.exists()
-    subj_2.delete()
-    assert not subj_2.exists()
-
-
-@skip_if_no_network
-def test_18_project_configuration():
+def test_16_project_configuration():
     project = central.select('/project/nosetests5')
     version = central.version()
     from pyxnat.core.errors import DatabaseError
@@ -265,8 +250,8 @@ def test_18_project_configuration():
         try:
             assert project.current_arc() == b'arc001'
         except DatabaseError:
-            msg = 'Check if current_arc is supported in XNAT version %s.'\
-                 % version['version']
+            msg = 'Check if current_arc is supported in XNAT version %s.' \
+                  % version['version']
             print(msg)
 
     assert 'nosetests' in project.users()
@@ -275,7 +260,7 @@ def test_18_project_configuration():
 
 
 @skip_if_no_network
-def test_19_put_zip():
+def test_17_put_zip():
     local_path = op.join(_modulepath, 'hello_dir.zip')
     assert op.exists(local_path)
 
@@ -294,9 +279,9 @@ def test_19_put_zip():
 
 
 @skip_if_no_network
-def test_20_get_zip():
+def test_18_get_zip():
     r = subj_1.resource('test_zip_extract')
-    local_dir = op.join(_modulepath, 'test_zip_download'+r.id())
+    local_dir = op.join(_modulepath, 'test_zip_download' + r.id())
     file_list = ['test_zip_extract/hello_dir',
                  'test_zip_extract/hello_dir/hello_xnat_dir.txt',
                  'test_zip_extract/hello_dir/hello_dir2',
@@ -314,13 +299,13 @@ def test_20_get_zip():
 
 
 @skip_if_no_network
-def test_21_project_aliases():
+def test_19_project_aliases():
     project = central.select('/project/nosetests5')
     assert project.aliases() == ['nosetests52']
 
 
 @skip_if_no_network
-def test_22_project():
+def test_20_project():
     project = central.select.project('nosetests5')
     project.datatype()
     project.experiments()
@@ -328,14 +313,14 @@ def test_22_project():
 
 
 @skip_if_no_network
-def test_22_project_description():
+def test_21_project_description():
     project = central.select.project('nosetests5')
     desc = project.description()
     assert(desc == 'nosetests')
 
 
 @skip_if_no_network
-def test_23_share_subject():
+def test_22_share_subject():
     target_project = central.select.project('metabase_nosetests')
 
     shared_subj_1 = target_project.subject(_id_set1['sid'])
@@ -349,7 +334,7 @@ def test_23_share_subject():
 
 
 @skip_if_no_network
-def test_24_unshare_subject():
+def test_23_unshare_subject():
     target_project = central.select.project('metabase_nosetests')
 
     shared_subj_1 = target_project.subject(_id_set1['sid'])
@@ -363,7 +348,7 @@ def test_24_unshare_subject():
 
 
 @skip_if_no_network
-def test_25_share_experiment():
+def test_24_share_experiment():
     target_project = central.select.project('metabase_nosetests')
 
     shared_expe_1 = target_project.experiment(_id_set1['eid'])
@@ -377,7 +362,7 @@ def test_25_share_experiment():
 
 
 @skip_if_no_network
-def test_26_unshare_experiment():
+def test_25_unshare_experiment():
     target_project = central.select.project('metabase_nosetests')
 
     shared_expe_1 = target_project.experiment(_id_set1['eid'])
@@ -388,3 +373,18 @@ def test_26_unshare_experiment():
     shared_expe_1 = target_project.experiment(_id_set1['eid'])
     assert(not shared_expe_1.exists())
     assert(expe_1.shares().get() == ['nosetests5'])
+
+
+@skip_if_no_network
+def test_26_subject1_delete():
+    assert subj_1.exists()
+    subj_1.delete()
+    assert not subj_1.exists()
+
+
+@skip_if_no_network
+def test_27_subject2_delete():
+    subj_2 = central.select('/projects/nosetests5/subjects/%(sid)s' % _id_set2)
+    assert subj_2.exists()
+    subj_2.delete()
+    assert not subj_2.exists()

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -101,55 +101,6 @@ def test_06_multi_create():
     assert scan_2.datatype() == 'xnat:mrScanData'
 
 
-# def test_share_subject():
-#    assert not central.select('/projects/nosetests2'
-#                              '/subjects/%(sid)s' % _id_set1
-#                              ).exists()
-#    subj_1.share('nosetests2')
-#    assert central.select('/projects/nosetests2/subjects/%(sid)s'%_id_set1
-#                              ).exists()
-#    assert set(subj_1.shares().get()) == set(['nosetests', 'nosetests2'])
-
-# def test_share_experiment():
-#    assert not central.select('/projects/nosetests2/subjects/%(sid)s'
-#                          '/experiments/%(eid)s'%_id_set1
-#                          ).exists()
-#    expe_1.share('nosetests2')
-#    assert central.select('/projects/nosetests2/subjects/%(sid)s'
-#                          '/experiments/%(eid)s'%_id_set1
-#                          ).exists()
-#    assert set(expe_1.shares().get()) == set(['nosetests', 'nosetests2'])
-
-# def test_share_assessor():
-#    assert not central.select('/projects/nosetests2/subjects/%(sid)s'
-#                              '/experiments/%(eid)s/assessors/%(aid)s'%_id_set1
-#                              ).exists()
-#    asse_1.share('nosetests2')
-#    assert central.select('/projects/nosetests2/subjects/%(sid)s'
-#                          '/experiments/%(eid)s/assessors/%(aid)s'%_id_set1
-#                          ).exists()
-#    assert set(asse_1.shares().get()) == set(['nosetests', 'nosetests2'])
-
-# def test_unshare_assessor():
-#    asse_1.unshare('nosetests2')
-#    assert not central.select('/projects/nosetests2/subjects/%(sid)s'
-#                              '/experiments/%(eid)s/assessors/%(aid)s'%_id_set1
-#                              ).exists()
-#    assert asse_1.shares().get() == ['nosetests']
-
-# def test_unshare_experiment():
-#    expe_1.unshare('nosetests2')
-#    assert not central.select('/projects/nosetests2/subjects/%(sid)s'
-#                          '/experiments/%(eid)s'%_id_set1
-#                          ).exists()
-#    assert expe_1.shares().get() == ['nosetests']
-
-# def test_unshare_subject():
-#    subj_1.unshare('nosetests2')
-#    assert not central.select('/projects/nosetests2/subjects/%(sid)s'%_id_set1
-#                              ).exists()
-#    assert subj_1.shares().get() == ['nosetests']
-
 @skip_if_no_network
 def test_07_put_file():
     local_path = op.join(_modulepath, 'hello_xnat.txt')
@@ -381,3 +332,59 @@ def test_22_project_description():
     project = central.select.project('nosetests5')
     desc = project.description()
     assert(desc == 'nosetests')
+
+
+@skip_if_no_network
+def test_23_share_subject():
+    target_project = central.select.project('metabase_nosetests')
+
+    shared_subj_1 = target_project.subject(_id_set1['sid'])
+    assert(not shared_subj_1.exists())
+    assert(subj_1.shares().get() == ['nosetests5'])
+
+    subj_1.share('metabase_nosetests')
+    shared_subj_1 = target_project.subject(_id_set1['sid'])
+    assert(shared_subj_1.exists())
+    assert(subj_1.shares().get() == ['nosetests5', 'metabase_nosetests'])
+
+
+@skip_if_no_network
+def test_24_unshare_subject():
+    target_project = central.select.project('metabase_nosetests')
+
+    shared_subj_1 = target_project.subject(_id_set1['sid'])
+    assert(shared_subj_1.exists())
+    assert(subj_1.shares().get() == ['nosetests5', 'metabase_nosetests'])
+
+    subj_1.unshare('metabase_nosetests')
+    shared_subj_1 = target_project.subject(_id_set1['sid'])
+    assert(not shared_subj_1.exists())
+    assert(subj_1.shares().get() == ['nosetests5'])
+
+
+@skip_if_no_network
+def test_25_share_experiment():
+    target_project = central.select.project('metabase_nosetests')
+
+    shared_expe_1 = target_project.experiment(_id_set1['eid'])
+    assert(not shared_expe_1.exists())
+    assert(expe_1.shares().get() == ['nosetests5'])
+
+    expe_1.share('metabase_nosetests')
+    shared_expe_1 = target_project.experiment(_id_set1['eid'])
+    assert(shared_expe_1.exists())
+    assert(expe_1.shares().get() == ['nosetests5', 'metabase_nosetests'])
+
+
+@skip_if_no_network
+def test_26_unshare_experiment():
+    target_project = central.select.project('metabase_nosetests')
+
+    shared_expe_1 = target_project.experiment(_id_set1['eid'])
+    assert(shared_expe_1.exists())
+    assert(expe_1.shares().get() == ['nosetests5', 'metabase_nosetests'])
+
+    expe_1.unshare('metabase_nosetests')
+    shared_expe_1 = target_project.experiment(_id_set1['eid'])
+    assert(not shared_expe_1.exists())
+    assert(expe_1.shares().get() == ['nosetests5'])


### PR DESCRIPTION
I added further features from the XNAT Data Sharing API (https://wiki.xnat.org/display/XAPI/Data+Sharing+API)

`label` is defined either as the original label or can be provided by the user (without this parameter, the shared subject or experiment did not show up properly in my xnat server)

`primary` from the XNAT API: _Optional querystring parameter. If set to "true", you are changing the primary ownership of the subject from the original project to the new project. Logged-in user must have ownership permissions in both projects to change the primary ownership._

Setting `primary` to `True` will enable moving a subject/experiment from one project to another project. 