### PR TITLE
Move docs generation to a new workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,25 +54,3 @@ jobs:
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  docs:
-    runs-on: '${{ matrix.os }}'
-    strategy:
-      matrix:
-        os: ['ubuntu-latest']
-        python-version: ['3.7']
-
-    steps:
-      - name: 'Set up Python ${{ matrix.python-version }}'
-        uses: actions/setup-python@v3
-        with:
-          python-version: '${{ matrix.python-version }}'
-      - uses: actions/checkout@v3
-      - run: python --version
-      - run: python -m pip install --upgrade pip
-      - name: Install sphinx
-        run: pip install sphinx sphinx_theme
-      - name: Build docs
-        run: ./build-docs.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        python-version: ['3.7']
+
+    steps:
+      - name: 'Set up Python ${{ matrix.python-version }}'
+        uses: actions/setup-python@v3
+        with:
+          python-version: '${{ matrix.python-version }}'
+      - uses: actions/checkout@v3
+      - run: python --version
+      - run: python -m pip install --upgrade pip
+      - name: Install sphinx
+        run: pip install sphinx sphinx_theme
+      - name: Build and deploy to GitHub Pages
+        run: ./build-docs.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Migrate automated docs generation (and publishing) job to a new independent GitHub-Actions workflow for more fine-grained configuration of both CI and docs automated actions.  
Also, configure the new workflow to only trigger its execution when new changes are pushed to the `master` branch. 
