### PR TITLE
REF: use xnat4test for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
       - run: python -m pip install --upgrade pip
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
-      - name: Install sphinx
-        run: pip install sphinx sphinx_theme
-        if: ${{ matrix.python-version == '3.7' }}
       - name: Start xnat4test
         run: xnat4tests_launch
       - name: Run tests (nose)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,7 @@ jobs:
         with:
           python-version: '${{ matrix.python-version }}'
       - uses: actions/checkout@v3
-      - name: Checkout xnat-docker-compose
-        uses: actions/checkout@v3
-        with:
-          repository: NrgXnat/xnat-docker-compose
-          ref: 1.8.1
-          path: xnat-docker-compose
-      - run: docker-compose --version
+      - run: docker --version
       - run: python --version
       - run: python -m pip install --upgrade pip
       - name: Install dependencies
@@ -38,13 +32,8 @@ jobs:
       - name: Install sphinx
         run: pip install sphinx sphinx_theme
         if: ${{ matrix.python-version == '3.7' }}
-      - name: Start xnat-docker-compose
-        run: docker-compose up -d
-        working-directory: xnat-docker-compose
-      - run: sleep 120
-      - name: Check xnat-docker-compose
-        run: docker-compose logs --tail=20 xnat-web
-        working-directory: xnat-docker-compose
+      - name: Start xnat4test
+        run: xnat4tests_launch
       - name: Run tests (nose)
         run: nosetests pyxnat/tests --nologcapture --with-coverage --cover-inclusive --cover-erase --cover-package .
         env:

--- a/.xnat.cfg
+++ b/.xnat.cfg
@@ -1,3 +1,3 @@
 {"password": "admin",
 "user": "admin",
-"server": "http://localhost"}
+"server": "http://localhost:8080"}

--- a/pyxnat/tests/sessionmirror_test.py
+++ b/pyxnat/tests/sessionmirror_test.py
@@ -2,6 +2,7 @@ import sys
 import os.path as op
 import pyxnat
 from . import skip_if_no_network
+import uuid
 
 _modulepath = op.dirname(op.abspath(pyxnat.__file__))
 dd = op.join(op.split(_modulepath)[0], 'bin')
@@ -11,13 +12,14 @@ cfg = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 central = pyxnat.Interface(config=cfg)
 
 src_project = 'nosetests5'
-dest_project = 'testing_new'
+dest_project = str(uuid.uuid4())[-22:]
 
 
 @skip_if_no_network
 def test_001_sessionmirror():
     from sessionmirror import create_parser, main, subj_compare
     e = 'CENTRAL02_E01892'
+    central.select.project(dest_project).create()
     parser = create_parser()
     args = ['--h1', cfg, '--h2', cfg, '-e', e, '-p', dest_project]
     args = parser.parse_args(args)
@@ -45,6 +47,6 @@ def test_002_delete_experiment():
     p = central.select.project(dest_project)
     e2 = p.subject(e1['subject_ID']).experiment(e1['ID'])
     assert(e2.exists())
-    e2.delete()
+    p.delete(delete_files=True)
     assert(not e2.exists())
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ future>=0.16
 nose>=1.2.1
 coverage>=3.6
 coveralls
+xnat4tests>=0.2.5
 # extras
 pandas>=0.24
 networkx>=2.2


### PR DESCRIPTION
Replace xnat-docker-compose setting used in CI for testing administrative and user related pyxnat features for a simpler approach using a single Docker container deployment of XNAT called [xnat4tests](https://github.com/Australian-Imaging-Service/xnat4tests).  

New XNAT deployment is installed as a Python dependency package and can be operated via CLI in the CI workflow. XNAT instance runs by default at port 8080.

An additional/unrelated change has been included ([REF: use randomly created projects for sessionmirror tests](https://github.com/pyxnat/pyxnat/commit/9a41be96288d565ab81ee196786b4626e77d1c61)), to avoid collisions between CI workflow runs when testing `sessionmirror` script against the very same XNAT (central) entities. Now uses a randomly generated project created (and removed) on the fly at execution time. 

PR closes https://github.com/pyxnat/pyxnat/issues/163.