### PR TITLE
Add digest (hash) to File attributes

### DIFF
--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1846,7 +1846,9 @@ class Resource(EObject):
             resources = self._intf._get_json(base_url)
             res_info = [r for r in resources
                         if r['xnat_abstractresource_id'] == resource_id][0]
-            fs = sizeof_fmt(float(res_info['file_size']))
+            fs = '0.0 B'
+            if res_info['file_size'] != '':
+                fs = sizeof_fmt(float(res_info['file_size']))
 
             # Creating the output string
             output = '<{cl} Object> {id} `{label}` ({fc} files {fs})'
@@ -2079,11 +2081,10 @@ class Resource(EObject):
                 )
 
     def attributes(self):
-        """ Files attributes include:
-                - URI
-                - Name
-                - Size in bytes
-                - path (relative to the parent resource)
+        """ Resource attributes include:
+                - label
+                - file_count
+                - file_size in bytes
                 - tags
                 - format
                 - content
@@ -2092,7 +2093,7 @@ class Resource(EObject):
             dict : a dictionary with the resource attributes
         """
 
-        return self._getcells(['URI', 'Name', 'Size', 'path',
+        return self._getcells(['label', 'file_count', 'file_size',
                                'tags', 'format', 'content'])
 
 
@@ -2151,8 +2152,8 @@ class File(EObject):
             dict : a dictionary with the file attributes
         """
 
-        return self._getcells(['URI', 'Name', 'Size', 'path',
-                               'file_tags', 'file_format', 'file_content', 'digest'])
+        return self._getcells(['URI', 'Name', 'Size', 'path', 'digest',
+                               'file_tags', 'file_format', 'file_content'])
 
     def get(self, dest=None):
         """ Downloads the file.

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -2144,6 +2144,7 @@ class File(EObject):
                 - file_tags
                 - file_format
                 - file_content
+                - digest
 
             Returns
             -------
@@ -2151,7 +2152,7 @@ class File(EObject):
         """
 
         return self._getcells(['URI', 'Name', 'Size', 'path',
-                               'file_tags', 'file_format', 'file_content'])
+                               'file_tags', 'file_format', 'file_content', 'digest'])
 
     def get(self, dest=None):
         """ Downloads the file.

--- a/pyxnat/tests/array_test.py
+++ b/pyxnat/tests/array_test.py
@@ -20,7 +20,7 @@ class ArrayTests(unittest.TestCase):
         of experiments (i.e. MRSessions and PETSessions) and assert it gathers
         them all.
         '''
-        e = self._intf.array.experiments(subject_id='CENTRAL_S06242').data
+        e = self._intf.array.experiments(subject_id='CENTRAL02_S01346').data
         self.assertGreaterEqual(len(e), 3)
 
     @skip_if_no_network
@@ -30,8 +30,8 @@ class ArrayTests(unittest.TestCase):
         list of MRI sessions and assert its length matches the list of
         experiments of type 'xnat:mrSessionData'
         '''
-        mris = self._intf.array.mrsessions(subject_id='CENTRAL_S06242').data
-        e = self._intf.array.experiments(subject_id='CENTRAL_S06242',
+        mris = self._intf.array.mrsessions(subject_id='CENTRAL02_S01346').data
+        e = self._intf.array.experiments(subject_id='CENTRAL02_S01346',
                                          experiment_type='xnat:mrSessionData')
         exps = e.data
         self.assertListEqual(mris, exps)
@@ -42,8 +42,8 @@ class ArrayTests(unittest.TestCase):
         Get a list of scans from a given experiment which has multiple types
         of scans (i.e. PETScans and CTScans) and assert it gathers them all.
         '''
-        s = self._intf.array.scans(experiment_id='CENTRAL_E72012').data
-        self.assertEqual(len(s), 16)
+        s = self._intf.array.scans(experiment_id='CENTRAL03_E05157').data
+        self.assertEqual(len(s), 4)
 
     @skip_if_no_network
     def test_array_mrscans(self):
@@ -53,8 +53,8 @@ class ArrayTests(unittest.TestCase):
         and assert its length matches the list of scans filtered by type
         'xnat:mrScanData'
         '''
-        mris = self._intf.array.mrscans(experiment_id='CENTRAL_E72012').data
-        exps = self._intf.array.scans(experiment_id='CENTRAL_E72012',
+        mris = self._intf.array.mrscans(experiment_id='CENTRAL02_E01892').data
+        exps = self._intf.array.scans(experiment_id='CENTRAL02_E01892',
                                       scan_type='xnat:mrScanData').data
         self.assertListEqual([i['xnat:mrscandata/id'] for i in mris],
                              [i['xnat:mrscandata/id'] for i in exps])


### PR DESCRIPTION
Add XNAT hash to file attributes (if file exists). This could be useful especially for testing and database integrity.

Credits to @vferat. 