### PR TITLE
MRTRIX3 and XCP-D derivatives

### DIFF
--- a/pyxnat/core/derivatives/cat12.py
+++ b/pyxnat/core/derivatives/cat12.py
@@ -25,8 +25,8 @@ def volumes(self):
 
 
 def download_rc(self, path):
-    '''Downloads a local copy of DARTEL imports. (Keep in mind that in CAT12
-    images are named rp*, not rc*.'''
+    """Downloads a local copy of DARTEL imports. (Keep in mind that in CAT12
+    images are named rp*, not rc*."""
     import os.path as op
     rc_files = ['mri/rp1', 'mri/rp2']
     for each in rc_files:

--- a/pyxnat/core/derivatives/dtifit.py
+++ b/pyxnat/core/derivatives/dtifit.py
@@ -2,7 +2,7 @@ XNAT_RESOURCE_NAMES = ['TOPUP_DTIFIT', 'DTIFIT', 'DWI_PREPROCESSING']
 
 
 def download_maps(self, path):
-    '''Downloads a local copy of DWI maps (MD, FA, L1 ~axial, RD)'''
+    """Downloads a local copy of DWI maps (MD, FA, L1 ~axial, RD)"""
     import os.path as op
     rc_files = ['MD', 'FA', 'L1', 'RD']
     for each in rc_files:

--- a/pyxnat/core/derivatives/mrtrix3.py
+++ b/pyxnat/core/derivatives/mrtrix3.py
@@ -1,0 +1,28 @@
+XNAT_RESOURCE_NAMES = ['MRTRIX3']
+
+
+def conmat(self):
+    """Returns the structural connectivity matrix (Desikan-Killiany atlas)."""
+    import pandas as pd
+    from io import StringIO
+
+    def _get_dk_lut():
+        """Retrieves from MRtrix3 sources the lookup table with the relevant
+        regions from the default FreeSurfer segmentation (Desikan-Killiany)."""
+
+        url = 'https://raw.githubusercontent.com/MRtrix3/mrtrix3/3.0.4/share/mrtrix3/labelconvert/fs_default.txt'
+        cols = ['label_index', 'label_code', 'label', 'R', 'G', 'B', 'n_colors']
+
+        raw_data = self._intf._http.get(url).content.decode('utf-8')
+        data = [ln.split() for ln in raw_data.splitlines()
+                if ln and ln[0] not in ['#', '0'] and '-Proper ' not in ln]
+        return pd.DataFrame(data, columns=cols)
+
+    dk_lut = _get_dk_lut()
+
+    f = self.file('connectome.csv')
+    content = self._intf.get(f._uri).content.decode('utf-8')
+    df = pd.read_csv(StringIO(content), names=dk_lut.label, header=None)
+    df.index = df.columns
+
+    return df

--- a/pyxnat/core/derivatives/spm12.py
+++ b/pyxnat/core/derivatives/spm12.py
@@ -25,7 +25,7 @@ def volumes(self):
 
 
 def download_rc(self, path):
-    '''Downloads a local copy of DARTEL imports.'''
+    """Downloads a local copy of DARTEL imports."""
     import os.path as op
     rc_files = ['rc1', 'rc2']
     for each in rc_files:

--- a/pyxnat/core/derivatives/xcp_d.py
+++ b/pyxnat/core/derivatives/xcp_d.py
@@ -1,0 +1,25 @@
+XNAT_RESOURCE_NAMES = ['XCP_D']
+
+
+def conmat(self, atlas='DK'):
+    """Returns the functional connectivity matrix from the specified atlas."""
+    import pandas as pd
+    from io import StringIO
+
+    f = self.files(f'*_atlas-{atlas}_measure-pearsoncorrelation_conmat.tsv')[0]
+    content = self._intf.get(f._uri).content.decode('utf-8')
+    df = pd.read_table(StringIO(content), sep='\t').drop(columns=['Node'])
+
+    return df
+
+
+def timeseries(self, atlas='DK'):
+    """Returns the parcellated BOLD time-series from the specified atlas."""
+    import pandas as pd
+    from io import StringIO
+
+    f = self.files(f'*_atlas-{atlas}_timeseries.tsv')[0]
+    content = self._intf.get(f._uri).content.decode('utf-8')
+    df = pd.read_table(StringIO(content), sep='\t')
+
+    return df

--- a/pyxnat/tests/test_resource_functions.py
+++ b/pyxnat/tests/test_resource_functions.py
@@ -204,3 +204,10 @@ def test_qsmxt_stats():
     q = 'roi == "Right-Pallidum"'
     rh_pallidum = stats.query(q)['mean'].item()
     assert (rh_pallidum > 0)
+
+
+def test_mrtrix3_conmat():
+    r = e1.resource('MRTRIX3')
+    df = r.conmat()
+    assert df['Left-Hippocampus']['ctx-lh-parahippocampal'] > 2.0
+    assert df['Right-Hippocampus']['ctx-rh-parahippocampal'] > 2.0

--- a/pyxnat/tests/test_resource_functions.py
+++ b/pyxnat/tests/test_resource_functions.py
@@ -211,3 +211,35 @@ def test_mrtrix3_conmat():
     df = r.conmat()
     assert df['Left-Hippocampus']['ctx-lh-parahippocampal'] > 2.0
     assert df['Right-Hippocampus']['ctx-rh-parahippocampal'] > 2.0
+
+
+def test_xcp_d_conmat():
+    r = e1.resource('XCP_D')
+    df = r.conmat(atlas='DK')
+    assert df.shape == (109, 109)
+
+    df2 = df.dropna(axis=0, how='all').dropna(axis=1, how='all')
+    assert df2.shape == (99, 99)
+    assert set(df.columns).difference(df2.columns) == {'Optic-Chiasm',
+                                                       'ctx-lh-frontalpole',
+                                                       'ctx-lh-lateralorbitofrontal',
+                                                       'ctx-lh-medialorbitofrontal',
+                                                       'ctx-lh-temporalpole',
+                                                       'ctx-rh-entorhinal',
+                                                       'ctx-rh-frontalpole',
+                                                       'ctx-rh-lateralorbitofrontal',
+                                                       'ctx-rh-medialorbitofrontal',
+                                                       'ctx-rh-temporalpole'}
+
+
+def test_xcp_d_timeseries():
+    r = e1.resource('XCP_D')
+    df = r.conmat(atlas='DK')
+    ts = r.timeseries(atlas='DK')
+    assert ts.shape == (287, 109)
+    assert df.shape[0] == ts.shape[1]
+
+    df2 = df.dropna(axis=0, how='all').dropna(axis=1, how='all')
+    ts2 = ts.dropna(axis=0, how='all').dropna(axis=1, how='all')
+    assert ts2.shape == (287, 99)
+    assert df2.shape[0] == ts2.shape[1]


### PR DESCRIPTION
This PR includes methods for fetching both structural (`MRTRIX3`) and functional (`FMRIPREP` + `XCP-D`) connectivity matrices as pandas DataFrame objects. 

