### PR TITLE
Switch XNAT for CI tests (#173)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,18 @@ jobs:
       - name: Check xnat-docker-compose
         run: docker-compose logs --tail=20 xnat-web
         working-directory: xnat-docker-compose
+      - name: create config json (Central/NITRC)
+        id: create-json-central
+        uses: jsdaniell/create-json@v1.2.2
+        with:
+          name: ".central.cfg"
+          json: ${{ secrets.CENTRAL_CFG }}
+      - name: create config json (devxnat)
+        id: create-json-devxnat
+        uses: jsdaniell/create-json@v1.2.2
+        with:
+          name: ".devxnat.cfg"
+          json: ${{ secrets.XNAT_CFG }}
       - name: Run tests (pytest)
         run: pytest
         env:

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1772,9 +1772,7 @@ class Reconstruction(EObject):
         self.provenance = Provenance(self)
 
     def datatype(self):
-        return (super(Reconstruction, self).datatype()
-                or 'xnat:reconstructedImageData'
-                )
+        return 'xnat:reconstructedImageData'
 
 
 @add_metaclass(ElementType)

--- a/pyxnat/tests/array_test.py
+++ b/pyxnat/tests/array_test.py
@@ -1,5 +1,4 @@
 import unittest
-import os.path as op
 from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 import logging as log
@@ -10,8 +9,7 @@ class ArrayTests(unittest.TestCase):
     ''' Resource-related XNAT connectivity test cases '''
 
     def setUp(self):
-        fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-        self._intf = Interface(config=fp)
+        self._intf = Interface('https://www.nitrc.org/ir', anonymous=True)
 
     @skip_if_no_network
     def test_array_experiments(self):
@@ -20,8 +18,8 @@ class ArrayTests(unittest.TestCase):
         of experiments (i.e. MRSessions and PETSessions) and assert it gathers
         them all.
         '''
-        e = self._intf.array.experiments(subject_id='CENTRAL02_S01346').data
-        self.assertGreaterEqual(len(e), 3)
+        e = self._intf.array.experiments(subject_id='XNAT_S04207').data
+        self.assertEqual(len(e), 2)
 
     @skip_if_no_network
     def test_array_mrsessions(self):
@@ -30,8 +28,8 @@ class ArrayTests(unittest.TestCase):
         list of MRI sessions and assert its length matches the list of
         experiments of type 'xnat:mrSessionData'
         '''
-        mris = self._intf.array.mrsessions(subject_id='CENTRAL02_S01346').data
-        e = self._intf.array.experiments(subject_id='CENTRAL02_S01346',
+        mris = self._intf.array.mrsessions(subject_id='XNAT_S04207').data
+        e = self._intf.array.experiments(subject_id='XNAT_S04207',
                                          experiment_type='xnat:mrSessionData')
         exps = e.data
         self.assertListEqual(mris, exps)
@@ -42,8 +40,8 @@ class ArrayTests(unittest.TestCase):
         Get a list of scans from a given experiment which has multiple types
         of scans (i.e. PETScans and CTScans) and assert it gathers them all.
         '''
-        s = self._intf.array.scans(experiment_id='CENTRAL03_E05157').data
-        self.assertEqual(len(s), 4)
+        s = self._intf.array.scans(experiment_id='XNAT_E16718').data
+        self.assertEqual(len(s), 1)
 
     @skip_if_no_network
     def test_array_mrscans(self):
@@ -53,8 +51,8 @@ class ArrayTests(unittest.TestCase):
         and assert its length matches the list of scans filtered by type
         'xnat:mrScanData'
         '''
-        mris = self._intf.array.mrscans(experiment_id='CENTRAL02_E01892').data
-        exps = self._intf.array.scans(experiment_id='CENTRAL02_E01892',
+        mris = self._intf.array.mrscans(experiment_id='NITRC_IR_E10539').data
+        exps = self._intf.array.scans(experiment_id='NITRC_IR_E10539',
                                       scan_type='xnat:mrScanData').data
         self.assertListEqual([i['xnat:mrscandata/id'] for i in mris],
                              [i['xnat:mrscandata/id'] for i in exps])
@@ -62,7 +60,7 @@ class ArrayTests(unittest.TestCase):
     @skip_if_no_network
     def test_search_experiments(self):
         et = 'xnat:subjectData'
-        e = self._intf.array.search_experiments(project_id='nosetests5',
+        e = self._intf.array.search_experiments(project_id='ixi',
                                                 experiment_type=et)
         res = e.data
-        self.assertGreaterEqual(len(res), 1)
+        self.assertEqual(len(res), 584)

--- a/pyxnat/tests/attributes_test.py
+++ b/pyxnat/tests/attributes_test.py
@@ -6,16 +6,14 @@ from pyxnat import Interface
 from pyxnat.core import interfaces
 
 
-_modulepath = op.dirname(op.abspath(__file__))
-
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
 interfaces.STUBBORN = True
 
 sid = uuid1().hex
 eid = uuid1().hex
 
-subject = central.select.project('nosetests5').subject(sid)
+subject = central.select.project('pyxnat_tests').subject(sid)
 experiment = subject.experiment(eid)
 
 
@@ -102,9 +100,9 @@ def test_06_list_project_attrs():
                           'xnat:projectData/fields/field',
                           'xnat:projectData/fields/field/None']
 
-    p = central.select.project('nosetests')
-    assert(p.attrs() == [])
+    p = central.select.project('pyxnat_tests')
+    assert p.attrs() == []
 
     central.manage.schemas.add('xapi/schemas/xnat')
-    p = central.select.project('nosetests')
-    assert (p.attrs() == project_attributes)
+    p = central.select.project('pyxnat_tests')
+    assert p.attrs() == project_attributes

--- a/pyxnat/tests/custom_variables_test.py
+++ b/pyxnat/tests/custom_variables_test.py
@@ -5,9 +5,10 @@ import os.path as op
 from pyxnat.tests import skip_if_no_network
 
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
-project = central.select.project('nosetests5')
+project = central.select.project('pyxnat_tests')
 
 variables = {'Subjects': {'newgroup': {'foo': 'string', 'bar': 'int'}}}
 

--- a/pyxnat/tests/custom_variables_test.py
+++ b/pyxnat/tests/custom_variables_test.py
@@ -5,7 +5,6 @@ import os.path as op
 from pyxnat.tests import skip_if_no_network
 
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
 project = central.select.project('pyxnat_tests')

--- a/pyxnat/tests/downloadutils_test.py
+++ b/pyxnat/tests/downloadutils_test.py
@@ -1,17 +1,17 @@
 from pyxnat import Interface
 from pyxnat.core import downloadutils as du
-import os.path as op
 from pyxnat.tests import skip_if_no_network
+import tempfile
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-central = Interface(config=fp)
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 
 @skip_if_no_network
 def test_download():
-    s = central.select.project('CENTRAL_OASIS_LONG').subject('OAS2_0001')
-    e = s.experiment('CENTRAL_E00090')
-    du.download(dest_dir='/tmp',
+    s = central.select.project('dlbs').subject('XNAT_S04207')
+    e = s.experiment('XNAT_E16269')
+    du.download(dest_dir=tempfile.gettempdir(),
                 instance=e.scans(),
                 extract=True,
                 removeZip=True)

--- a/pyxnat/tests/downloadutils_test.py
+++ b/pyxnat/tests/downloadutils_test.py
@@ -3,7 +3,6 @@ from pyxnat.core import downloadutils as du
 from pyxnat.tests import skip_if_no_network
 import tempfile
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 

--- a/pyxnat/tests/experiments_test.py
+++ b/pyxnat/tests/experiments_test.py
@@ -1,15 +1,13 @@
-import os.path as op
 from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 
-_modulepath = op.dirname(op.abspath(__file__))
-
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-central = Interface(config=fp)
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#central = Interface(config=fp)
+central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 
 @skip_if_no_network
 def test_global_experiment_listing():
-    assert central.array.experiments(project_id='CENTRAL_OASIS_CS',
+    assert central.array.experiments(project_id='ixi',
                                      experiment_type='xnat:mrSessionData',
                                      )

--- a/pyxnat/tests/experiments_test.py
+++ b/pyxnat/tests/experiments_test.py
@@ -1,8 +1,6 @@
 from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-#central = Interface(config=fp)
 central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 

--- a/pyxnat/tests/graphdata_test.py
+++ b/pyxnat/tests/graphdata_test.py
@@ -1,11 +1,8 @@
 from pyxnat.core.help import GraphData, PaintGraph, SchemasInspector
 from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
-import os.path as op
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-central = Interface(config=fp)
-
+central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 @skip_if_no_network
 def test_graphdata():

--- a/pyxnat/tests/inspector_test.py
+++ b/pyxnat/tests/inspector_test.py
@@ -1,7 +1,5 @@
 from pyxnat import Interface
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-#central = Interface(config=fp)
 central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 

--- a/pyxnat/tests/inspector_test.py
+++ b/pyxnat/tests/inspector_test.py
@@ -1,8 +1,8 @@
 from pyxnat import Interface
-import os.path as op
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-central = Interface(config=fp)
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#central = Interface(config=fp)
+central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 
 def test_inspector_structure():

--- a/pyxnat/tests/interfaces_test.py
+++ b/pyxnat/tests/interfaces_test.py
@@ -2,7 +2,6 @@ import os.path as op
 from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 fp = op.abspath('.central.cfg')
 central = Interface(config=fp)
 central_anon = Interface('https://www.nitrc.org/ir', anonymous=True)

--- a/pyxnat/tests/interfaces_test.py
+++ b/pyxnat/tests/interfaces_test.py
@@ -2,9 +2,10 @@ import os.path as op
 from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+fp = op.abspath('.central.cfg')
 central = Interface(config=fp)
-central_anon = Interface('https://central.xnat.org', anonymous=True)
+central_anon = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 
 def test_simple_object_listing():
@@ -16,21 +17,21 @@ def test_simple_path_listing():
 
 
 def test_nested_object_listing():
-    assert isinstance(central.select.projects('*OASIS*').subjects().get(),
+    assert isinstance(central.select.projects('*00*').subjects().get(),
                       list)
 
 
 def test_nested_path_listing():
-    assert isinstance(central.select('/projects/*OASIS*/subjects').get(), list)
+    assert isinstance(central.select('/projects/*00*/subjects').get(), list)
 
 
 @skip_if_no_network
 def test_search_access():
-    constraints = [('xnat:subjectData/PROJECT', '=', 'CENTRAL_OASIS_CS'),
+    constraints = [('xnat:subjectData/PROJECT', '=', 'ixi'),
                    'AND']
 
     for subject in central.select('//subjects').where(constraints):
-        assert '/projects/CENTRAL_OASIS_CS' in subject._uri
+        assert '/projects/ixi' in subject._uri
 
 
 def test_connection_with_explicit_parameters():
@@ -48,9 +49,8 @@ def test_anonymous_access():
 
 @skip_if_no_network
 def test_close_jsession():
-    config_file = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-    with Interface(config=config_file) as central:
-        assert central.select.project('nosetests').exists()
+    with Interface(config=fp) as central_intf:
+        assert central_intf.select.project('OASIS3').exists()
 
 
 def test_save_config():
@@ -60,7 +60,7 @@ def test_save_config():
 @skip_if_no_network
 def test_version():
     v = central.version()
-    assert(v['version'] == '1.7.5.2-SNAPSHOT')
+    assert v['version'] == '1.7.6'
 
 
 def test_login_using_explicit_credentials():

--- a/pyxnat/tests/manage_test.py
+++ b/pyxnat/tests/manage_test.py
@@ -2,8 +2,6 @@ from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-#central = Interface(config=fp)
 central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 notified = []

--- a/pyxnat/tests/manage_test.py
+++ b/pyxnat/tests/manage_test.py
@@ -1,10 +1,10 @@
-import os.path as op
 from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-central = Interface(config=fp)
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#central = Interface(config=fp)
+central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 notified = []
 
@@ -29,6 +29,6 @@ def test_unregister_callback():
 
 @skip_if_no_network
 def test_add_schema():
-    assert(len(central.manage.schemas()) == 0)
+    assert len(central.manage.schemas()) == 0
     central.manage.schemas.add(url='/xapi/schemas/xnat')
-    assert(list(central.manage.schemas()) == ['xnat'])
+    assert list(central.manage.schemas()) == ['xnat']

--- a/pyxnat/tests/pipelines_test.py
+++ b/pyxnat/tests/pipelines_test.py
@@ -2,9 +2,11 @@ import os.path as op
 from pyxnat import Interface
 from pyxnat.core.pipelines import PipelineNotFoundError
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#central = Interface(config=fp)
+fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
-p = central.select.project('nosetests5')
+p = central.select.project('pyxnat_tests')
 
 
 def test_pipelines_info():
@@ -18,19 +20,19 @@ def test_pipelines_aliases():
 
 
 def test_pipeline_info():
-    info_keys = ['appliesTo', 'authors', 'description',
-                 'inputParameters', 'path', 'steps', 'version']
+    info_keys = {'appliesTo', 'authors', 'description', 'inputParameters',
+                 'path', 'resourceRequirements', 'steps', 'version'}
 
     pipe = p.pipelines.pipeline('DicomToNifti')
     assert (pipe.exists())
 
     pipe_info = pipe.info()
-    assert (int(pipe_info['version']) >= 20150114)
-    assert (sorted(pipe_info.keys()) == info_keys)
+    assert (int(pipe_info['version']) >= 20190308)
+    assert (set(pipe_info.keys()) == info_keys)
 
 
 def test_pipeline_run():
-    exp_id = 'CENTRAL02_E01603'
+    exp_id = 'BBRCDEV_E03094'
 
     try:
         wrong_pipe = p.pipelines.pipeline('INVALID_PIPELINE')
@@ -49,7 +51,7 @@ def test_pipeline_run():
 
 
 def test_pipeline_status():
-    exp_id = 'CENTRAL02_E01603'
+    exp_id = 'BBRCDEV_E03094'
 
     try:
         wrong_pipe = p.pipelines.pipeline('INVALID_PIPELINE')

--- a/pyxnat/tests/pipelines_test.py
+++ b/pyxnat/tests/pipelines_test.py
@@ -2,8 +2,6 @@ import os.path as op
 from pyxnat import Interface
 from pyxnat.core.pipelines import PipelineNotFoundError
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-#central = Interface(config=fp)
 fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
 p = central.select.project('pyxnat_tests')

--- a/pyxnat/tests/prearchive_test.py
+++ b/pyxnat/tests/prearchive_test.py
@@ -2,7 +2,9 @@ from pyxnat import Interface
 import os.path as op
 from pyxnat.tests import skip_if_no_network
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#central = Interface(config=fp)
+fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
 
 
@@ -15,7 +17,7 @@ def test_prearchive_get():
 
 @skip_if_no_network
 def test_prearchive_status():
-    triple = ['SAFMD', '20170602_161757472', '_4']
+    triple = ['pyxnat_tests', '20240122_173812916', 'sub-001_ses-01']
     from pyxnat.core import manage
     pa = manage.PreArchive(central)
     assert(pa.status(triple) == 'READY')

--- a/pyxnat/tests/prearchive_test.py
+++ b/pyxnat/tests/prearchive_test.py
@@ -2,8 +2,6 @@ from pyxnat import Interface
 import os.path as op
 from pyxnat.tests import skip_if_no_network
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-#central = Interface(config=fp)
 fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
 

--- a/pyxnat/tests/project_manager_test.py
+++ b/pyxnat/tests/project_manager_test.py
@@ -2,8 +2,10 @@ from pyxnat import manage
 from pyxnat import Interface
 import os.path as op
 
-x = Interface(config=op.join(op.dirname(op.abspath(__file__)), 'central.cfg'))
+#x = Interface(config=op.join(op.dirname(op.abspath(__file__)), 'central.cfg'))
+central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 
 def test_project_manager():
-    manage.ProjectManager('nosetests', x)
+    mgmt = manage.ProjectManager('ABIDE', central)
+    assert mgmt.accessibility().decode() == 'protected'

--- a/pyxnat/tests/project_manager_test.py
+++ b/pyxnat/tests/project_manager_test.py
@@ -2,7 +2,6 @@ from pyxnat import manage
 from pyxnat import Interface
 import os.path as op
 
-#x = Interface(config=op.join(op.dirname(op.abspath(__file__)), 'central.cfg'))
 central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 

--- a/pyxnat/tests/provenance_test.py
+++ b/pyxnat/tests/provenance_test.py
@@ -4,7 +4,6 @@ from pyxnat import Interface
 import os.path as op
 
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
 project = central.select.project('pyxnat_tests')

--- a/pyxnat/tests/provenance_test.py
+++ b/pyxnat/tests/provenance_test.py
@@ -4,9 +4,10 @@ from pyxnat import Interface
 import os.path as op
 
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
-project = central.select.project('nosetests5')
+project = central.select.project('pyxnat_tests')
 
 prov = {
     'program': 'young',

--- a/pyxnat/tests/repr_test.py
+++ b/pyxnat/tests/repr_test.py
@@ -1,16 +1,15 @@
+import pyxnat.core.resources
 from pyxnat import Interface
 import os.path as op
 from pyxnat.tests import skip_if_no_network
 
-_modulepath = op.dirname(op.abspath(__file__))
-
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-print(fp)
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
 
-proj_1 = central.select.project('surfmask_smpl2')
-subj_1 = proj_1.subject('CENTRAL05_S01120')
-exp_1 = subj_1.experiment('CENTRAL05_E02681')
+proj_1 = central.select.project('pyxnat_tests')
+subj_1 = proj_1.subject('BBRCDEV_S02627')
+exp_1 = subj_1.experiment('BBRCDEV_E03106')
 scan_1 = exp_1.scan('11')
 resource_1 = exp_1.resource('obscure_algorithm_output')
 
@@ -23,130 +22,143 @@ resource_2 = scan_2.resource('IOP')
 
 @skip_if_no_network
 def test_project_exists():
-    if proj_1.exists():
-        assert isinstance(proj_1, object)
-        assert str(proj_1) != '<Project Object> NFB'
+    assert proj_1.exists()
+    assert isinstance(proj_1, object)
+    assert isinstance(proj_1, pyxnat.core.resources.Project)
+    assert str(proj_1) != '<Project Object> NFB'
 
 
 @skip_if_no_network
 def test_project_not_exists():
-    if not proj_2.exists():
-        assert isinstance(proj_2, object)
-        assert str(proj_2) == '<Project Object> NFB'
+    assert not proj_2.exists()
+    assert isinstance(proj_2, object)
+    assert isinstance(proj_2, pyxnat.core.resources.Project)
+    assert str(proj_2) == '<Project Object> NFB'
 
 
 @skip_if_no_network
 def test_info_project():
-    assert isinstance(proj_1, object)
-    expected_output = '<Project Object> surfmask_smpl2 `Surface masking '\
-        'samples 2` (private) 1 subject 1 MR experiment (owner: nosetests) '\
-        '(created on 2020-10-22 15:23:39.458) https://central.xnat.org/data/'\
-        'projects/surfmask_smpl2?format=html'
-    assert list(sorted(str(proj_1))) == list(sorted(expected_output))
+    assert proj_1.exists()
+    expected_output = (
+        f'<Project Object> pyxnat_tests `pyxnat tests` (private) 3 subjects '
+        f'5 MR experiments 1 CT experiment 1 PET experiment '
+        f'(owner: {central._user}) (created on 2024-01-22 10:09:22.086) '
+        f'{central._server}/data/projects/pyxnat_tests?format=html')
+    assert str(proj_1) == expected_output
 
 
 @skip_if_no_network
 def test_subject_exists():
-    if subj_1.exists():
-        assert isinstance(subj_1, object)
-        assert str(subj_1) != '<Subject Object> BOA'
+    assert subj_1.exists()
+    assert isinstance(subj_1, object)
+    assert isinstance(subj_1, pyxnat.core.resources.Subject)
+    assert str(subj_1) != '<Subject Object> BOA'
 
 
 @skip_if_no_network
 def test_subject_not_exists():
-    if not subj_2.exists():
-        assert isinstance(subj_2, object)
-        assert str(subj_2) == '<Subject Object> BOA'
+    assert not subj_2.exists()
+    assert isinstance(subj_2, object)
+    assert isinstance(subj_2, pyxnat.core.resources.Subject)
+    assert str(subj_2) == '<Subject Object> BOA'
 
 
 @skip_if_no_network
 def test_info_subject():
-    assert isinstance(subj_1, object)
-    expected_output = '<Subject Object> CENTRAL05_S01120 `001` (project: '\
-        'surfmask_smpl2) (Gender: U) 1 experiment https://central.xnat.org/'\
-        'data/projects/surfmask_smpl2/subjects/CENTRAL05_S01120?format=html'
-    assert list(sorted(str(subj_1))) == list(sorted(expected_output))
+    assert subj_1.exists()
+    expected_output = (
+        f'<Subject Object> BBRCDEV_S02627 `001` (project: pyxnat_tests) '
+        f'(Gender: U) 1 experiment {central._server}/data/projects/'
+        f'pyxnat_tests/subjects/BBRCDEV_S02627?format=html')
+    assert str(subj_1) == expected_output
 
 
 @skip_if_no_network
 def test_experiment_exists():
-    if exp_1.exists():
-        assert isinstance(exp_1, object)
-        assert str(exp_1) != '<Experiment Object> GHJ'
+    assert exp_1.exists()
+    assert isinstance(exp_1, object)
+    assert isinstance(exp_1, pyxnat.core.resources.Experiment)
+    assert str(exp_1) != '<Experiment Object> GHJ'
 
 
 @skip_if_no_network
 def test_experiment_not_exists():
-    if not exp_2.exists():
-        assert isinstance(exp_2, object)
-        assert str(exp_2) == '<Experiment Object> GHJ'
+    assert not exp_2.exists()
+    assert isinstance(exp_2, object)
+    assert isinstance(exp_2, pyxnat.core.resources.Experiment)
+    assert str(exp_2) == '<Experiment Object> GHJ'
 
 
 @skip_if_no_network
 def test_info_experiment():
-    assert isinstance(exp_1, object)
-    expected_output = '<Experiment Object> CENTRAL05_E02681 `001_obscured` (subject: '\
-        'CENTRAL05_S01120 `001`) (project: surfmask_smpl2) 4 scans 1 resource '\
-        '(created on 2020-10-22 15:24:30.139) https://central.xnat.org/'\
-        'data/projects/surfmask_smpl2/subjects/CENTRAL05_S01120/experiments/'\
-        'CENTRAL05_E02681?format=html'
-    assert list(sorted(str(exp_1))) == list(sorted(expected_output))
+    assert exp_1.exists()
+    expected_output = (
+        f'<Experiment Object> BBRCDEV_E03106 `001_obscured` '
+        f'(subject: BBRCDEV_S02627 `001`) (project: pyxnat_tests) '
+        f'4 scans 1 resource (created on 2024-01-22 10:25:48.637) '
+        f'{central._server}/data/projects/pyxnat_tests/subjects/'
+        f'BBRCDEV_S02627/experiments/BBRCDEV_E03106?format=html')
+    assert str(exp_1) == expected_output
 
 
 @skip_if_no_network
 def test_scan_exists():
-    if scan_1.exists():
-        assert isinstance(scan_1, object)
-        assert str(scan_1) != '<Scan Object> JKL'
+    assert scan_1.exists()
+    assert isinstance(scan_1, object)
+    assert isinstance(scan_1, pyxnat.core.resources.Scan)
+    assert str(scan_1) != '<Scan Object> JKL'
 
 
 @skip_if_no_network
 def test_scan_not_exists():
-    if not scan_2.exists():
-        assert isinstance(scan_2, object)
-        assert str(scan_2) == '<Scan Object> JKL'
+    assert not scan_2.exists()
+    assert isinstance(scan_2, object)
+    assert isinstance(scan_2, pyxnat.core.resources.Scan)
+    assert str(scan_2) == '<Scan Object> JKL'
 
 
 @skip_if_no_network
 def test_info_scan():
-    assert isinstance(scan_1, object)
-    expected_output = '<Scan Object> 11 (`SPGR` 175 frames)  '\
-        'https://central.xnat.org/data/projects/surfmask_smpl2/subjects/'\
-        'CENTRAL05_S01120/experiments/CENTRAL05_E02681/scans/11?format=html'
-    assert list(sorted(str(scan_1))) == list(sorted(expected_output))
+    assert scan_1.exists()
+    expected_output = (
+        f'<Scan Object> 11 (`SPGR` 175 frames)  {central._server}/data/'
+        f'projects/pyxnat_tests/subjects/BBRCDEV_S02627/experiments/'
+        f'BBRCDEV_E03106/scans/11?format=html')
+    assert str(scan_1) == expected_output
 
 
 @skip_if_no_network
 def test_resource_exists():
-    if resource_1.exists():
-        assert isinstance(resource_1, object)
-        assert str(resource_1) != '<Resource Object> IOP'
+    assert resource_1.exists()
+    assert isinstance(resource_1, object)
+    assert isinstance(resource_1, pyxnat.core.resources.Resource)
+    assert str(resource_1) != '<Resource Object> IOP'
 
 
 @skip_if_no_network
 def test_resource_not_exists():
-    if not resource_2.exists():
-        assert isinstance(resource_2, object)
-        assert str(resource_2) == '<Resource Object> IOP'
+    assert not resource_2.exists()
+    assert isinstance(resource_2, object)
+    assert isinstance(resource_2, pyxnat.core.resources.Resource)
+    assert str(resource_2) == '<Resource Object> IOP'
 
 
 @skip_if_no_network
 def test_info_resource():
-    assert isinstance(resource_1, object)
-    expected_output = '<Resource Object> 123361501 '\
-        '`obscure_algorithm_output` (66 files 2.06 GB)'
-    assert list(sorted(str(resource_1))) == list(sorted(expected_output))
+    assert resource_1.exists()
+    expected_output = (
+        f'<Resource Object> 19551 `obscure_algorithm_output` (66 files 2.06 GB)')
+    assert str(resource_1) == expected_output
 
 
 @skip_if_no_network
 def test_create_delete_create():
-    p = central.select.project('nosetests5')
     from uuid import uuid1
     sid = uuid1().hex
-    s = p.subject(sid)
+    s = proj_1.subject(sid)
     s.create()
-    assert(s.exists())
+    assert s.exists()
     s.delete()
     s.create()
     s.delete()
-    assert(not s.exists())
+    assert not s.exists()

--- a/pyxnat/tests/repr_test.py
+++ b/pyxnat/tests/repr_test.py
@@ -3,7 +3,6 @@ from pyxnat import Interface
 import os.path as op
 from pyxnat.tests import skip_if_no_network
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
 

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -10,8 +10,6 @@ from pyxnat.core import interfaces
 
 _modulepath = op.dirname(op.abspath(__file__))
 
-#central = Interface(config=op.join(op.dirname(op.abspath(__file__)),
-#                                   'central.cfg'))
 fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
 

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -74,9 +74,11 @@ def test_05_reconstruction_create():
     assert reco_1.exists()
 
 
-# def test_provenance():
-#     reco_1.provenance.set({'program':'nosetests'})
-#     assert reco_1.provenance.get()[0]['program'] == 'nosetests'
+@skip_if_no_network
+def test_provenance():
+    reco_1.provenance.set({'program': 'nosetests'})
+    assert reco_1.provenance.get()[0]['program'] == 'nosetests'
+
 
 @skip_if_no_network
 def test_06_multi_create():

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -323,7 +323,63 @@ def test_21_project_description():
 
 
 @skip_if_no_network
-def test_22_delete_data():
+def test_22_share_subject():
+    target_project = central.select.project('pyxnat_tests2')
+
+    shared_subj_1 = target_project.subject(_id_set1['sid'])
+    assert (not shared_subj_1.exists())
+    assert (subj_1.shares().get() == ['pyxnat_tests'])
+
+    subj_1.share('pyxnat_tests2')
+    shared_subj_1 = target_project.subject(_id_set1['sid'])
+    assert (shared_subj_1.exists())
+    assert (subj_1.shares().get() == ['pyxnat_tests', 'pyxnat_tests2'])
+
+
+@skip_if_no_network
+def test_23_unshare_subject():
+    target_project = central.select.project('pyxnat_tests2')
+
+    shared_subj_1 = target_project.subject(_id_set1['sid'])
+    assert (shared_subj_1.exists())
+    assert (subj_1.shares().get() == ['pyxnat_tests', 'pyxnat_tests2'])
+
+    subj_1.unshare('pyxnat_tests2')
+    shared_subj_1 = target_project.subject(_id_set1['sid'])
+    assert (not shared_subj_1.exists())
+    assert (subj_1.shares().get() == ['pyxnat_tests'])
+
+
+@skip_if_no_network
+def test_24_share_experiment():
+    target_project = central.select.project('pyxnat_tests2')
+
+    shared_expe_1 = target_project.experiment(_id_set1['eid'])
+    assert (not shared_expe_1.exists())
+    assert (expe_1.shares().get() == ['pyxnat_tests'])
+
+    expe_1.share('pyxnat_tests2')
+    shared_expe_1 = target_project.experiment(_id_set1['eid'])
+    assert (shared_expe_1.exists())
+    assert (expe_1.shares().get() == ['pyxnat_tests', 'pyxnat_tests2'])
+
+
+@skip_if_no_network
+def test_25_unshare_experiment():
+    target_project = central.select.project('pyxnat_tests2')
+
+    shared_expe_1 = target_project.experiment(_id_set1['eid'])
+    assert (shared_expe_1.exists())
+    assert (expe_1.shares().get() == ['pyxnat_tests', 'pyxnat_tests2'])
+
+    expe_1.unshare('pyxnat_tests2')
+    shared_expe_1 = target_project.experiment(_id_set1['eid'])
+    assert (not shared_expe_1.exists())
+    assert (expe_1.shares().get() == ['pyxnat_tests'])
+
+
+@skip_if_no_network
+def test_26_subjects_delete():
     for sid in [_id_set1['sid'], _id_set2['sid']]:
         subj = central.select.project('pyxnat_tests').subject(sid)
         if subj.exists():

--- a/pyxnat/tests/scans_test.py
+++ b/pyxnat/tests/scans_test.py
@@ -1,17 +1,14 @@
 from pyxnat import Interface
-import os.path as op
 from pyxnat.tests import skip_if_no_network
 
 
-_modulepath = op.dirname(op.abspath(__file__))
-
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-central = Interface(config=fp)
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#central = Interface(config=fp)
+central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 
 @skip_if_no_network
 def test_global_scan_listing():
-    assert central.array.scans(project_id='CENTRAL_OASIS_CS',
+    assert central.array.scans(project_id='ixi',
                                experiment_type='xnat:mrSessionData',
-                               scan_type='xnat:mrScanData'
-                               )
+                               scan_type='xnat:mrScanData')

--- a/pyxnat/tests/scans_test.py
+++ b/pyxnat/tests/scans_test.py
@@ -2,8 +2,6 @@ from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-#central = Interface(config=fp)
 central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 

--- a/pyxnat/tests/search_test.py
+++ b/pyxnat/tests/search_test.py
@@ -3,7 +3,8 @@ from pyxnat import Interface
 from pyxnat import jsonutil
 import os.path as op
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+fp = op.abspath('.central.cfg')
 central = Interface(config=fp)
 search_name = uuid1().hex
 search_template_name = uuid1().hex
@@ -26,17 +27,17 @@ def test_fieldvalues():
 
 
 def test_inspect_resources():
-    assert 'OAS1_0440_MR1' in \
+    assert 'xnat_E02579' in \
         central.inspect.experiment_values('xnat:mrSessionData',
-                                          'CENTRAL_OASIS_CS')
+                                          'cs_schizbull08')
 
-    assert 'OAS1_0286_MR1_FSEG' in \
+    assert 'xnat_E02580' in \
         central.inspect.assessor_values('xnat:mrSessionData',
-                                        'CENTRAL_OASIS_CS')
+                                        'cs_schizbull08')
 
-    assert 'mpr-1' in \
+    assert 'anat' in \
         central.inspect.scan_values('xnat:mrSessionData',
-                                    'CENTRAL_OASIS_CS')
+                                    'cs_schizbull08')
 
     # just coverage
     assert isinstance(central.inspect.experiment_types(), list)
@@ -51,7 +52,8 @@ def test_search():
     results = central.select(
         'xnat:mrSessionData',
         central.inspect.datatypes('xnat:mrSessionData')
-        ).where([('xnat:mrSessionData/SCANNER', 'LIKE', '*GE*'), 'AND'])
+        ).where([('xnat:mrSessionData/XNAT_COL_MRSESSIONDATAFIELDSTRENGTH',
+                  'LIKE', '*1.5*'), 'AND'])
 
     assert isinstance(results, jsonutil.JsonTable)
 
@@ -60,7 +62,8 @@ def test_save_search():
     central.manage.search.save(
         search_name, 'xnat:mrSessionData',
         central.inspect.datatypes('xnat:mrSessionData'),
-        [('xnat:mrSessionData/SCANNER', 'LIKE', '*GE*'), 'AND'])
+        [('xnat:mrSessionData/XNAT_COL_MRSESSIONDATAFIELDSTRENGTH',
+          'LIKE', '*1.5*'), 'AND'])
 
     assert search_name in central.manage.search.saved()
 
@@ -79,7 +82,8 @@ def test_save_search_template():
     central.manage.search.save_template(
         search_template_name, 'xnat:mrSessionData',
         central.inspect.datatypes('xnat:mrSessionData'),
-        [('xnat:mrSessionData/SCANNER', 'LIKE', '*GE*'), 'AND']
+        [('xnat:mrSessionData/XNAT_COL_MRSESSIONDATAFIELDSTRENGTH',
+          'LIKE', '*1.5*'), 'AND']
         )
 
     assert search_template_name in central.manage.search.saved_templates()

--- a/pyxnat/tests/search_test.py
+++ b/pyxnat/tests/search_test.py
@@ -3,7 +3,6 @@ from pyxnat import Interface
 from pyxnat import jsonutil
 import os.path as op
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
 fp = op.abspath('.central.cfg')
 central = Interface(config=fp)
 search_name = uuid1().hex

--- a/pyxnat/tests/sessionmirror_test.py
+++ b/pyxnat/tests/sessionmirror_test.py
@@ -7,17 +7,17 @@ _modulepath = op.dirname(op.abspath(pyxnat.__file__))
 dd = op.join(op.split(_modulepath)[0], 'bin')
 sys.path.append(dd)
 
-cfg = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+cfg = op.abspath('.devxnat.cfg')
 central = pyxnat.Interface(config=cfg)
 
-src_project = 'nosetests5'
-dest_project = 'testing_new'
+src_project = 'pyxnat_tests'
+dest_project = 'pyxnat_tests2'
 
 
 @skip_if_no_network
 def test_001_sessionmirror():
     from sessionmirror import create_parser, main, subj_compare
-    e = 'CENTRAL02_E01892'
+    e = 'BBRCDEV_E03099'
     parser = create_parser()
     args = ['--h1', cfg, '--h2', cfg, '-e', e, '-p', dest_project]
     args = parser.parse_args(args)
@@ -27,13 +27,13 @@ def test_001_sessionmirror():
     data = central.array.experiments(experiment_id=e, columns=cols).data[0]
     s1 = central.select.project(src_project).subject(data['subject_label'])
     s2 = central.select.project(dest_project).subject(data['subject_label'])
-    assert(subj_compare(s1, s2) == 0)
+    assert (subj_compare(s1, s2) == 0)
 
 
 @skip_if_no_network
 def test_002_delete_experiment():
     print('DELETING')
-    e = 'CENTRAL02_E01892'
+    e = 'BBRCDEV_E03099'
     cols = ['subject_label', 'label']
     e0 = central.array.experiments(experiment_id=e, columns=cols).data[0]
     subject_label = e0['subject_label']
@@ -44,7 +44,7 @@ def test_002_delete_experiment():
                                    columns=['subject_id']).data[0]
     p = central.select.project(dest_project)
     e2 = p.subject(e1['subject_ID']).experiment(e1['ID'])
-    assert(e2.exists())
+    assert (e2.exists())
     e2.delete()
-    assert(not e2.exists())
+    assert (not e2.exists())
 

--- a/pyxnat/tests/test_resource_functions.py
+++ b/pyxnat/tests/test_resource_functions.py
@@ -1,12 +1,12 @@
 import os.path as op
 from pyxnat import Interface
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-
+fp = op.abspath('.devxnat.cfg')
 central = Interface(config=fp)
 
+
 def test_ashs_volumes():
-    r = central.select.experiment('CENTRAL02_E01603').resource('ASHS')
+    r = central.select.experiment('BBRCDEV_E03094').resource('ASHS')
     hv = r.volumes()
     v = hv.query('region=="CA1" & side=="left"')['volume'].tolist()[0]
-    assert(v == 1287.675)
+    assert (v == 1287.675)

--- a/pyxnat/tests/user_and_project_management_test.py
+++ b/pyxnat/tests/user_and_project_management_test.py
@@ -5,7 +5,7 @@ from functools import wraps
 import pytest
 
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+fp = op.abspath('.devxnat.cfg')
 
 
 def docker_available(func=None):
@@ -159,25 +159,24 @@ def test_create_xml():
 
 def test_project_users():
     x = Interface(config=fp)
-    assert isinstance(x.select.project('nosetests5').users(), list)
+    assert isinstance(x.select.project('pyxnat_tests').users(), list)
 
 
 def test_project_owners():
     x = Interface(config=fp)
-    assert isinstance(x.select.project('nosetests5').owners(), list)
+    assert isinstance(x.select.project('pyxnat_tests').owners(), list)
 
 
 def test_project_members():
     x = Interface(config=fp)
-    assert isinstance(x.select.project('nosetests5').members(), list)
+    assert isinstance(x.select.project('pyxnat_tests').members(), list)
 
 
 def test_project_collaborators():
     x = Interface(config=fp)
-    assert isinstance(x.select.project('nosetests5').collaborators(),
-                      list)
+    assert isinstance(x.select.project('pyxnat_tests').collaborators(), list)
 
 
 def test_project_user_role():
     x = Interface(config=fp)
-    assert x.select.project('nosetests5').user_role('nosetests') == 'owner'
+    assert x.select.project('pyxnat_tests').user_role(x._user) == 'owner'

--- a/pyxnat/tests/xpass_test.py
+++ b/pyxnat/tests/xpass_test.py
@@ -4,34 +4,34 @@ from pyxnat import xpass
 def test_find_plus_line():
     print("Testing find_plus_line")
     test = ['hello', '+hello world', '']
-    assert(xpass.find_plus_line(test) == 'hello world')
+    assert (xpass.find_plus_line(test) == 'hello world')
     test2 = ['', 'hello world']
-    assert(xpass.find_plus_line(test2) is None)
+    assert (xpass.find_plus_line(test2) is None)
     test3 = []
-    assert(xpass.find_plus_line(test3) is None)
+    assert (xpass.find_plus_line(test3) is None)
 
 
 def test_find_token():
     print("Testing find_token")
-    str = "hello,world"
-    assert(xpass.find_token(',', str) == ('hello', 'world'))
-    assert(xpass.find_token(' ', str) is None)
+    string = "hello,world"
+    assert (xpass.find_token(',', string) == ('hello', 'world'))
+    assert (xpass.find_token(' ', string) is None)
 
 
 def test_parse_xnat_pass():
     print("Testing parse_xnat_pass")
-    nothingLine = ""
+    nothing_line = ""
     line = "+user@localhost:8080/xnat=password"
-    lineWithSpaces = "+user@localhost:8080/xnat=password     "
-    lineWithoutPlus = "user@localhost:8080/xnat=password"
-    lineWithoutUser = "+@localhost:8080/xnat=password"
-    lineWithoutHost = "+user=password"
-    lineWithoutPass = "+user@localhost:8080/xnat"
-    xp = xpass.parse_xnat_pass([nothingLine, line])
-    assert(xp == {'p': 'password', 'host': 'localhost:8080/xnat', 'u': 'user'})
-    xp = xpass.parse_xnat_pass([lineWithSpaces])
-    assert(xp == {'p': 'password', 'host': 'localhost:8080/xnat', 'u': 'user'})
-    assert(xpass.parse_xnat_pass([lineWithoutPlus]) is None)
-    assert(xpass.parse_xnat_pass([lineWithoutUser]) is None)
-    assert(xpass.parse_xnat_pass([lineWithoutHost]) is None)
-    assert(xpass.parse_xnat_pass([lineWithoutPass]) is None)
+    line_with_spaces = "+user@localhost:8080/xnat=password     "
+    line_without_plus = "user@localhost:8080/xnat=password"
+    line_without_user = "+@localhost:8080/xnat=password"
+    line_without_host = "+user=password"
+    line_without_pass = "+user@localhost:8080/xnat"
+    xp = xpass.parse_xnat_pass([nothing_line, line])
+    assert (xp == {'p': 'password', 'host': 'localhost:8080/xnat', 'u': 'user'})
+    xp = xpass.parse_xnat_pass([line_with_spaces])
+    assert (xp == {'p': 'password', 'host': 'localhost:8080/xnat', 'u': 'user'})
+    assert (xpass.parse_xnat_pass([line_without_plus]) is None)
+    assert (xpass.parse_xnat_pass([line_without_user]) is None)
+    assert (xpass.parse_xnat_pass([line_without_host]) is None)
+    assert (xpass.parse_xnat_pass([line_without_pass]) is None)

--- a/pyxnat/tests/xpath_test.py
+++ b/pyxnat/tests/xpath_test.py
@@ -2,20 +2,21 @@ import os.path as op
 from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 
-fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-central = Interface(config=fp)
+#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
+#central = Interface(config=fp)
+central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 
 @skip_if_no_network
 def test_001_xpath_checkout():
-    central.xpath.checkout(subjects=['OAS1_0001', 'OAS1_0002'])
-    assert 'OAS1_0001' in central.xpath.subjects() and \
-        'OAS1_0002' in central.xpath.subjects()
+    central.xpath.checkout(subjects=['xnat_S02582', 'xnat_S02583'])
+    assert 'xnat_S02582' in central.xpath.subjects() and \
+        'xnat_S02583' in central.xpath.subjects()
 
 
 @skip_if_no_network
 def test_elements():
-    assert 'fs:region' in central.xpath.elements()
+    assert 'xnat:voxelRes' in central.xpath.elements()
 
 
 @skip_if_no_network
@@ -25,15 +26,11 @@ def test_keys():
 
 @skip_if_no_network
 def test_values():
-    assert 'OAS1_0002' in central.xpath.values('ID')
+    assert 'xnat_S02582' in central.xpath.values('ID')
 
 
 @skip_if_no_network
 def test_element_attrs():
-    assert isinstance(central.xpath.element_attrs('fs:region'), list)
-
-    assert set(['SegId', 'hemisphere', 'name']).issubset(
-        central.xpath.element_keys('fs:region'))
-
-    assert 'Left-Putamen' in \
-        central.xpath.element_values('fs:region', 'name')
+    assert isinstance(central.xpath.element_attrs('xnat:voxelRes'), list)
+    assert {'x', 'y', 'z'}.issubset(central.xpath.element_keys('xnat:voxelRes'))
+    assert '0.9375' in central.xpath.element_values('xnat:voxelRes', 'x')

--- a/pyxnat/tests/xpath_test.py
+++ b/pyxnat/tests/xpath_test.py
@@ -2,8 +2,6 @@ import os.path as op
 from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 
-#fp = op.join(op.dirname(op.abspath(__file__)), 'central.cfg')
-#central = Interface(config=fp)
 central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 


### PR DESCRIPTION
Replace Central XNAT as main infrastructure for CI testing as it's being decommissioned. 
This PR addresses #173 by redirecting/adjusting all CI tests from Central XNAT to (a) a public Central-alike instance (NITRC/IR) and (b) a development XNAT instance.