### PR TITLE
ENH: Add support for relative paths in config file (#180)

### DIFF
--- a/pyxnat/core/interfaces.py
+++ b/pyxnat/core/interfaces.py
@@ -433,8 +433,9 @@ class Interface(object):
             raise NotImplementedError(
                 'no save_config() for anonymous interfaces')
 
-        if not os.path.exists(os.path.dirname(location)):
-            os.makedirs(os.path.dirname(location))
+        expanded_path = os.path.abspath(os.path.expanduser(location))
+        if not os.path.exists(os.path.dirname(expanded_path)):
+            os.makedirs(os.path.dirname(expanded_path))
 
         config = {'server': self._server,
                   'user': self._user,
@@ -446,7 +447,7 @@ class Interface(object):
         if self._proxy_url:
             config['proxy'] = self._proxy_url.geturl()
 
-        with open(location, 'w') as fp:
+        with open(expanded_path, 'w') as fp:
             json.dump(config, fp)
 
     def load_config(self, location):

--- a/pyxnat/tests/interfaces_test.py
+++ b/pyxnat/tests/interfaces_test.py
@@ -55,18 +55,32 @@ def test_close_jsession():
 
 
 def test_save_config():
-    central.save_config('/tmp/.xnat.cfg')
+    with tempfile.TemporaryDirectory(dir=tempfile.gettempdir()) as tempdir:
+        cfg = op.join(tempdir, '.xnat.cfg')
+        central.save_config(cfg)
+        assert op.isfile(cfg)
+    assert not op.isfile(cfg)
+
 
 def test_save_config_home_dir():
-    filename = "test_config.txt"
-    with tempfile.TemporaryDirectory(dir=os.path.expanduser("~")) as tempdir:
-        central.save_config(os.path.join("~", os.path.basename(tempdir), filename))
-        assert os.path.exists(os.path.join(tempdir, filename))
+    with tempfile.TemporaryDirectory(dir=op.expanduser("~")) as tempdir:
+        cfg = op.join("~", op.basename(tempdir), '.xnat.cfg')
+        central.save_config(cfg)
+        assert op.isfile(op.expanduser(cfg))
+    assert not op.isfile(op.expanduser(cfg))
 
 
 def test_save_config_current_dir():
-    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as f:
-        central.save_config(os.path.basename(f.name))
+    f = tempfile.NamedTemporaryFile(dir=os.getcwd(), delete=False)
+    cfg = op.basename(f.name)
+    try:
+        f.close()
+        central.save_config(cfg)
+        assert op.isfile(cfg)
+    finally:
+        os.remove(cfg)
+    assert not op.isfile(cfg)
+
 
 @skip_if_no_network
 def test_version():

--- a/pyxnat/tests/interfaces_test.py
+++ b/pyxnat/tests/interfaces_test.py
@@ -65,10 +65,10 @@ def test_save_config_home_dir():
 
 
 def test_save_config_current_dir():
-    temp_dir_name = os.path.join(os.getcwd())
     filename = "test_config.txt"
-    with tempfile.TemporaryDirectory(dir=temp_dir_name) as tempdir:
-        central.save_config(os.path.join(tempdir, filename))
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tempdir:
+        relpath = os.path.join(os.path.basename(tempdir), filename)
+        central.save_config(relpath)
         assert os.path.exists(os.path.join(tempdir, filename))
 
 @skip_if_no_network

--- a/pyxnat/tests/interfaces_test.py
+++ b/pyxnat/tests/interfaces_test.py
@@ -65,11 +65,8 @@ def test_save_config_home_dir():
 
 
 def test_save_config_current_dir():
-    filename = "test_config.txt"
-    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tempdir:
-        relpath = os.path.join(os.path.basename(tempdir), filename)
-        central.save_config(relpath)
-        assert os.path.exists(os.path.join(tempdir, filename))
+    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as f:
+        central.save_config(os.path.basename(f.name))
 
 @skip_if_no_network
 def test_version():

--- a/pyxnat/tests/interfaces_test.py
+++ b/pyxnat/tests/interfaces_test.py
@@ -1,4 +1,6 @@
+import os
 import os.path as op
+import tempfile 
 from pyxnat import Interface
 from pyxnat.tests import skip_if_no_network
 
@@ -55,6 +57,19 @@ def test_close_jsession():
 def test_save_config():
     central.save_config('/tmp/.xnat.cfg')
 
+def test_save_config_home_dir():
+    filename = "test_config.txt"
+    with tempfile.TemporaryDirectory(dir=os.path.expanduser("~")) as tempdir:
+        central.save_config(os.path.join("~", os.path.basename(tempdir), filename))
+        assert os.path.exists(os.path.join(tempdir, filename))
+
+
+def test_save_config_current_dir():
+    temp_dir_name = os.path.join(os.getcwd())
+    filename = "test_config.txt"
+    with tempfile.TemporaryDirectory(dir=temp_dir_name) as tempdir:
+        central.save_config(os.path.join(tempdir, filename))
+        assert os.path.exists(os.path.join(tempdir, filename))
 
 @skip_if_no_network
 def test_version():


### PR DESCRIPTION
Fixes #180 by expanding the config file path for `save_config`

Credits to @Pkaps25