### PR TITLE
FIX: replace resources removed from in NITRC XNAT

### DIFF
--- a/pyxnat/tests/array_test.py
+++ b/pyxnat/tests/array_test.py
@@ -40,7 +40,7 @@ class ArrayTests(unittest.TestCase):
         Get a list of scans from a given experiment which has multiple types
         of scans (i.e. PETScans and CTScans) and assert it gathers them all.
         '''
-        s = self._intf.array.scans(experiment_id='XNAT_E16718').data
+        s = self._intf.array.scans(experiment_id='xnat_E02685').data
         self.assertEqual(len(s), 1)
 
     @skip_if_no_network

--- a/pyxnat/tests/downloadutils_test.py
+++ b/pyxnat/tests/downloadutils_test.py
@@ -8,8 +8,8 @@ central = Interface('https://www.nitrc.org/ir', anonymous=True)
 
 @skip_if_no_network
 def test_download():
-    s = central.select.project('dlbs').subject('XNAT_S04207')
-    e = s.experiment('XNAT_E16269')
+    s = central.select.project('cs_schizbull08').subject('xnat_S02636')
+    e = s.experiment('xnat_E02685')
     du.download(dest_dir=tempfile.gettempdir(),
                 instance=e.scans(),
                 extract=True,


### PR DESCRIPTION
Replace resources used for CI testing which aren't available anymore in the NITRC XNAT.