### PR TITLE
Fix saving of verify parameter in config, when set to False

### DIFF
--- a/pyxnat/core/interfaces.py
+++ b/pyxnat/core/interfaces.py
@@ -468,7 +468,7 @@ class Interface(object):
                   'user': self._user,
                   'password': self._pwd,
                   }
-        if self._verify:
+        if self._verify is not None:
             config['verify'] = self._verify
 
         if self._proxy_url:


### PR DESCRIPTION
When saving a config where `verify` is set to `False` (and not `None`), the `verify` parameter was not saved. 

Example (before fix): 
```python
>>> from pyxnat import Interface
>>> myxnat = Interface(server="https://myxnat.org", user="myuser", password="p@ssw0rd", verify=False)
>>> myxnat.save_config("myxnat.cfg")
```
Result (myxnat.cfg): 
```
{"server": "https://myxnat.org", "user": "mysuser", "password": "p@ssw0rd"}
```
After fix: 
```
{"server": "https://myxnat.org", "user": "mysuser", "password": "p@ssw0rd", "verify": false}
```
