### PR TITLE
p/core/*.py: fix SyntaxWarning.

### DIFF
--- a/pyxnat/core/attributes.py
+++ b/pyxnat/core/attributes.py
@@ -137,11 +137,11 @@ class EAttrs(object):
         else:
             header = header[0]
 
-        replaceSlashS = lambda x: x.replace('\s', ' ')
+        replaceSlashS = lambda x: x.replace(r'\s', ' ')
         if type(jdata.get(header)) == list:
             return map(replaceSlashS, jdata.get(header))
         else:
-            return jdata.get(header).replace('\s', ' ')
+            return jdata.get(header).replace(r'\s', ' ')
 
     def mget(self, paths):
         """ Set multiple attributes at once.
@@ -181,6 +181,6 @@ class EAttrs(object):
                 header = difflib.get_close_matches(path, jdata.headers())[0]
             else:
                 header = header[0]
-            results.append(jdata.get(header).replace('\s', ' '))
+            results.append(jdata.get(header).replace(r'\s', ' '))
 
         return results

--- a/pyxnat/core/xpath_store.py
+++ b/pyxnat/core/xpath_store.py
@@ -9,7 +9,7 @@ def get_subject_id(location):
     content = f.read()
     f.close()
 
-    subject = re.findall('<xnat:Subject\sID="(.*?)"\s', content)
+    subject = re.findall(r'<xnat:Subject\sID="(.*?)"\s', content)
 
     if subject != []:
         return subject[0]


### PR DESCRIPTION
This change declares various strings as raw strings to avoid attempts to parse single backslash characters as escape sequences.  They are otherwise flagged as invalid by newer Python versions.

This issue was initially reported as [Debian bug #1086983].

[Debian bug #1086983]: https://bugs.debian.org/1086983