### PR TITLE
FEAT: BAMOS_ARTERIAL resource

### DIFF
--- a/pyxnat/core/derivatives/bamos_arterial.py
+++ b/pyxnat/core/derivatives/bamos_arterial.py
@@ -1,12 +1,13 @@
 XNAT_RESOURCE_NAME = 'BAMOS_ARTERIAL'
 
+
 def stats(self):
+    """ Collects descriptive statistics based on the segmented lesions of the
+        white matter, including volumes and number of lesions per arterial
+        territory. A voxel is considered as a part of a lesion if it has a
+        value higher than 0.5."""
     import pandas as pd
-    import sys
-    if sys.version_info[0] < 3:
-        from StringIO import StringIO
-    else:
-        from io import StringIO
+    from io import StringIO
 
     f = self.file('bamos_arterial_stats.csv')
     uri = f._uri

--- a/pyxnat/core/derivatives/bamos_arterial.py
+++ b/pyxnat/core/derivatives/bamos_arterial.py
@@ -1,4 +1,4 @@
-XNAT_RESOURCE_NAME = 'BAMOS_ARTERIAL2'
+XNAT_RESOURCE_NAME = 'BAMOS_ARTERIAL'
 
 def stats(self):
     import pandas as pd

--- a/pyxnat/core/derivatives/bamos_arterial.py
+++ b/pyxnat/core/derivatives/bamos_arterial.py
@@ -1,0 +1,16 @@
+XNAT_RESOURCE_NAME = 'BAMOS_ARTERIAL2'
+
+def stats(self):
+    import pandas as pd
+    import sys
+    if sys.version_info[0] < 3:
+        from StringIO import StringIO
+    else:
+        from io import StringIO
+
+    f = self.file('bamos_arterial_stats.csv')
+    uri = f._uri
+    res = self._intf.get(uri).text
+    text = StringIO(res)
+    df = pd.read_csv(text)
+    return df

--- a/pyxnat/tests/test_resource_functions.py
+++ b/pyxnat/tests/test_resource_functions.py
@@ -313,3 +313,9 @@ def test_alps_fa_md_alps():
     fa_assoc, md_assoc = fa_md.mean_assoc
     assert fa_proj > md_proj
     assert fa_assoc > md_assoc
+
+
+def test_bamos_arterial_stats():
+    r = e1.resource('BAMOS_ARTERIAL')
+    v = r.stats()
+    assert(sum(v['volume']) == 1029.9175409973652)

--- a/pyxnat/tests/test_resource_functions.py
+++ b/pyxnat/tests/test_resource_functions.py
@@ -316,6 +316,7 @@ def test_alps_fa_md_alps():
 
 
 def test_bamos_arterial_stats():
+    from math import isclose
     r = e1.resource('BAMOS_ARTERIAL')
     v = r.stats()
-    assert(sum(v['volume']) == 1029.9175409973652)
+    assert isclose(sum(v['volume']), 32995.6548)


### PR DESCRIPTION
This PR adds the stats function to the new resource BAMOS_ARTERIAL. This resource is a BAMOS-derived resource to perform WMH volume quantification instead of using a lobe atlas, using an arterial territory atlas.