### PR TITLE
FEAT: te_asl derivatives

### DIFF
--- a/pyxnat/core/derivatives/te_asl.py
+++ b/pyxnat/core/derivatives/te_asl.py
@@ -1,0 +1,40 @@
+from . import basil
+
+XNAT_RESOURCE_NAMES = ['TE_ASL']
+
+
+def perfusion(self):
+    """Perfusion and arrival-time mean values"""
+    return basil.perfusion(self)
+
+
+def stats(self):
+    """Summary statistics for the perfusion values within each region
+    in the Harvard-Oxford cortical and subcortical atlases"""
+    import csv
+    import pandas as pd
+    import os.path as op
+
+    region_stats = []
+
+    stats_files = {'whole_brain_perfusion': 'region_analysis.csv',
+                   'GM_perfusion': 'region_analysis_gm.csv',
+                   'WM_perfusion': 'region_analysis_wm.csv',
+                   'whole_brain_arrival': 'region_analysis_arrival.csv',
+                   'GM_arrival': 'region_analysis_arrival_gm.csv',
+                   'WM_arrival': 'region_analysis_arrival_wm.csv'}
+    for roi, fn in stats_files.items():
+        f = self.files('*{}'.format(fn))[0]
+        content = self._intf.get(f.attributes()['URI']).text.splitlines()
+        for idx, ln in enumerate(csv.reader(content)):
+            if idx == 0:
+                cols = ['region_analysis'] + ln
+            elif idx > 0:
+                region_stats.append([roi] + ln)
+
+    df = pd.DataFrame(region_stats, columns=cols)
+    num_cols = ['Nvoxels', 'Mean', 'Std', 'Median',
+                'IQR', 'Precision-weighted mean', 'I2']
+    for col in num_cols:
+        df[col] = pd.to_numeric(df[col])
+    return df

--- a/pyxnat/core/derivatives/te_asl.py
+++ b/pyxnat/core/derivatives/te_asl.py
@@ -9,13 +9,14 @@ def perfusion(self):
 
 
 def stats(self):
-    """Summary statistics for the perfusion values within each region
-    in the Harvard-Oxford cortical and subcortical atlases"""
+    """Regional perfusion and arrival-time statistics.
+
+    Parses `oxford_asl` region-analysis CSV outputs for whole-brain (global),
+    GM and WM perfusion and arrival-time summaries based on the Harvard-Oxford
+    cortical and subcortical atlases.
+    """
     import csv
     import pandas as pd
-    import os.path as op
-
-    region_stats = []
 
     stats_files = {'whole_brain_perfusion': 'region_analysis.csv',
                    'GM_perfusion': 'region_analysis_gm.csv',
@@ -23,18 +24,21 @@ def stats(self):
                    'whole_brain_arrival': 'region_analysis_arrival.csv',
                    'GM_arrival': 'region_analysis_arrival_gm.csv',
                    'WM_arrival': 'region_analysis_arrival_wm.csv'}
+    region_stats = []
+    columns = []
     for roi, fn in stats_files.items():
-        f = self.files('*{}'.format(fn))[0]
+        f = self.files(f'*{fn}')[0]
         content = self._intf.get(f.attributes()['URI']).text.splitlines()
-        for idx, ln in enumerate(csv.reader(content)):
+        for idx, row in enumerate(csv.reader(content)):
             if idx == 0:
-                cols = ['region_analysis'] + ln
-            elif idx > 0:
-                region_stats.append([roi] + ln)
+                columns = ['region_analysis'] + row
+            else:
+                region_stats.append([roi] + row)
 
-    df = pd.DataFrame(region_stats, columns=cols)
-    num_cols = ['Nvoxels', 'Mean', 'Std', 'Median',
-                'IQR', 'Precision-weighted mean', 'I2']
-    for col in num_cols:
+    df = pd.DataFrame(region_stats, columns=columns)
+    numeric_cols = ['Nvoxels', 'Mean', 'Std', 'Median',
+                    'IQR', 'Precision-weighted mean', 'I2']
+    for col in numeric_cols:
         df[col] = pd.to_numeric(df[col])
+
     return df

--- a/pyxnat/tests/test_resource_functions.py
+++ b/pyxnat/tests/test_resource_functions.py
@@ -359,27 +359,32 @@ def test_fsl_anat_volumes():
 def test_te_asl_perfusion():
     r = e1.resource('TE_ASL')
     perf = r.perfusion()
-    assert(perf.shape == (24, 4))
+    assert perf.shape == (24, 4)
+
     q = 'pvcorr==True & measurement=="{measurement}"'
     gm_perf = perf.query(q.format(measurement="perfusion_calib_gm_mean"))['value'].item()
     wm_perf = perf.query(q.format(measurement="perfusion_calib_wm_mean"))['value'].item()
-    assert(gm_perf > wm_perf)
+    assert gm_perf > wm_perf
+
     gm_att = perf.query(q.format(measurement="arrival_gm_mean"))['value'].item()
     wm_att = perf.query(q.format(measurement="arrival_wm_mean"))['value'].item()
-    assert(wm_att > gm_att)
+    assert wm_att > gm_att
 
 
 def test_te_asl_stats():
     r = e1.resource('TE_ASL')
     stats = r.stats()
-    assert(stats.shape == (468, 9))
+    assert stats.shape == (468, 9)
+
     q = 'region_analysis=="{measurement}" & name=="Left Hippocampus"'
     nvoxels_gm = stats.query(q.format(measurement="GM_perfusion"))['Nvoxels'].item()
     nvoxels_wm = stats.query(q.format(measurement="WM_perfusion"))['Nvoxels'].item()
-    assert(nvoxels_gm > nvoxels_wm)
+    assert nvoxels_gm > nvoxels_wm
+
     gm_att = stats.query(q.format(measurement="GM_arrival"))['Mean'].item()
     wm_att = stats.query(q.format(measurement="WM_arrival"))['Mean'].item()
-    assert(wm_att > gm_att)
+    assert wm_att > gm_att
+
     gm_perf = stats.query(q.format(measurement="GM_perfusion"))['Mean'].item()
     wm_perf = stats.query(q.format(measurement="WM_perfusion"))['Mean'].item()
-    assert(gm_perf > wm_perf)
+    assert gm_perf > wm_perf

--- a/pyxnat/tests/test_resource_functions.py
+++ b/pyxnat/tests/test_resource_functions.py
@@ -338,13 +338,6 @@ def test_centaurz_quantification():
     assert rq2[rq2['measurement'] == 'suvr_spm8'].value.iloc[0] < 0.8
 
 
-def test_fsl_anat_volumes():
-    r = e1.resource('FSL_ANAT')
-    v = r.volumes()
-    # assert GM > WM > CSF
-    assert v['T1_fast_pve_1'] > v['T1_fast_pve_2'] > v['T1_fast_pve_0']
-
-
 def test_fsl_anat_subvolumes():
     r = e1.resource('FSL_ANAT')
     vols = r.subcortical_volumes()
@@ -355,3 +348,38 @@ def test_fsl_anat_subvolumes():
     assert vq1['volume'].values[0] > 20000
     assert vq2['volume'].values[0] < 500
 
+
+def test_fsl_anat_volumes():
+    r = e1.resource('FSL_ANAT')
+    v = r.volumes()
+    # assert GM > WM > CSF
+    assert v['T1_fast_pve_1'] > v['T1_fast_pve_2'] > v['T1_fast_pve_0']
+
+
+def test_te_asl_perfusion():
+    r = e1.resource('TE_ASL')
+    perf = r.perfusion()
+    assert(perf.shape == (24, 4))
+    q = 'pvcorr==True & measurement=="{measurement}"'
+    gm_perf = perf.query(q.format(measurement="perfusion_calib_gm_mean"))['value'].item()
+    wm_perf = perf.query(q.format(measurement="perfusion_calib_wm_mean"))['value'].item()
+    assert(gm_perf > wm_perf)
+    gm_att = perf.query(q.format(measurement="arrival_gm_mean"))['value'].item()
+    wm_att = perf.query(q.format(measurement="arrival_wm_mean"))['value'].item()
+    assert(wm_att > gm_att)
+
+
+def test_te_asl_stats():
+    r = e1.resource('TE_ASL')
+    stats = r.stats()
+    assert(stats.shape == (468, 9))
+    q = 'region_analysis=="{measurement}" & name=="Left Hippocampus"'
+    nvoxels_gm = stats.query(q.format(measurement="GM_perfusion"))['Nvoxels'].item()
+    nvoxels_wm = stats.query(q.format(measurement="WM_perfusion"))['Nvoxels'].item()
+    assert(nvoxels_gm > nvoxels_wm)
+    gm_att = stats.query(q.format(measurement="GM_arrival"))['Mean'].item()
+    wm_att = stats.query(q.format(measurement="WM_arrival"))['Mean'].item()
+    assert(wm_att > gm_att)
+    gm_perf = stats.query(q.format(measurement="GM_perfusion"))['Mean'].item()
+    wm_perf = stats.query(q.format(measurement="WM_perfusion"))['Mean'].item()
+    assert(gm_perf > wm_perf)


### PR DESCRIPTION
This PR adds the derivatives for the TE_ASL resource. The implementation follows the BASIL derivatives as a reference, with the addition of arrival time metrics in the regional statistics analysis.